### PR TITLE
Fixed: Issue #170 Building with Visual Studio 2012 & 2013 fails.

### DIFF
--- a/src/audio-sdlmixer.c
+++ b/src/audio-sdlmixer.c
@@ -29,6 +29,8 @@
 #include "SDL.h"
 #include "SDL_mixer.h"
 
+#include <string.h>
+
 /* Play sound. */
 
 typedef struct {

--- a/src/freeserf.cc
+++ b/src/freeserf.cc
@@ -19,7 +19,9 @@
  * along with freeserf.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _MSC_VER
 extern "C" {
+#endif
   #include "freeserf.h"
   #include "interface.h"
   #include "gfx.h"
@@ -34,7 +36,9 @@ extern "C" {
   #ifdef HAVE_CONFIG_H
   # include <config.h>
   #endif
+#ifndef _MSC_VER
 }
+#endif
 
 #include <cstdio>
 #include <cstdlib>
@@ -44,7 +48,10 @@ extern "C" {
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+
+#ifdef HAVE_STDINT_H
 #include <stdint.h>
+#endif
 
 #define DEFAULT_SCREEN_WIDTH  800
 #define DEFAULT_SCREEN_HEIGHT 600

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -25,6 +25,7 @@
 #include "log.h"
 
 #include <assert.h>
+#include <string.h>
 
 
 /* Unique identifier for a sprite. */
@@ -155,7 +156,7 @@ gfx_create_sprite(const dos_sprite_t *sprite)
 	uint8_t *dest = (uint8_t *)s + sizeof(sprite_t);
 	uint size = sprite->w * sprite->h;
 
-	for (int i = 0; i < size; i++) {
+	for (uint i = 0; i < size; i++) {
 		dest[4*i+0] = palette[3*src[i]+0]; /* Red */
 		dest[4*i+1] = palette[3*src[i]+1]; /* Green */
 		dest[4*i+2] = palette[3*src[i]+2]; /* Blue */
@@ -298,7 +299,7 @@ gfx_mask_waves_sprite(const sprite_t *sprite, const sprite_t *mask, int x_off)
 	uint8_t *dest_data = (uint8_t *)s + sizeof(sprite_t);
 
 	/* Copy data to new sprite */
-	for (int i = 0; i < height; i++) {
+	for (uint i = 0; i < height; i++) {
 		memcpy(dest_data, src_data, mask->width * 4);
 		src_data += 4*sprite->width;
 		dest_data += 4*mask->width;

--- a/src/pathfinder.cc
+++ b/src/pathfinder.cc
@@ -19,10 +19,18 @@
  * along with freeserf.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+#ifndef _MSC_VER
 extern "C" {
+#endif
   #include "pathfinder.h"
   #include "game.h"
+#ifndef _MSC_VER
 }
+#endif
+
+#undef min
+#undef max
 
 #include <cstdlib>
 #include <list>
@@ -61,7 +69,7 @@ heuristic_cost(map_pos_t start, map_pos_t end)
   int dist_row = (MAP_POS_ROW(start) - MAP_POS_ROW(end)) & game.map.row_mask;
   if (dist_row >= static_cast<int>(game.map.rows/2.0)) dist_row -= game.map.rows;
 
-  int h_diff = abs(MAP_HEIGHT(start) - MAP_HEIGHT(end));
+  int h_diff = abs((int)MAP_HEIGHT(start) - (int)MAP_HEIGHT(end));
   int dist = 0;
 
   if ((dist_col > 0 && dist_row > 0) ||
@@ -78,7 +86,7 @@ static uint
 actual_cost(map_pos_t pos, dir_t dir)
 {
   map_pos_t other_pos = MAP_MOVE(pos, dir);
-  int h_diff = abs(MAP_HEIGHT(pos) - MAP_HEIGHT(other_pos));
+  int h_diff = abs((int)MAP_HEIGHT(pos) - (int)MAP_HEIGHT(other_pos));
   return walk_cost[h_diff];
 }
 

--- a/windows/config.h
+++ b/windows/config.h
@@ -13,20 +13,23 @@ typedef signed __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 typedef signed __int64 int64_t;
 typedef unsigned __int64 uint64_t;
-#	ifndef _UINTPTR_T_DEFINED
-#		ifdef  _WIN64
+#		ifndef _UINTPTR_T_DEFINED
+#			ifdef  _WIN64
 typedef unsigned __int64 uintptr_t;
-#		else
+#			else
 typedef unsigned int uintptr_t;
-#	endif
-#		define _UINTPTR_T_DEFINED
-#	endif
+#		endif
+#			define _UINTPTR_T_DEFINED
+#		endif
 
-#	include <stdio.h>
-#	include <stdarg.h>
+#		pragma warning( disable : 4996)
 
-#	ifndef snprintf
-#		define snprintf c99_snprintf
+#		include <stdio.h>
+#		include <stdarg.h>
+#		include <search.h>
+
+#		ifndef snprintf
+#			define snprintf c99_snprintf
 
 inline int c99_vsnprintf(char* str, size_t size, const char* format, va_list ap)
 {
@@ -52,8 +55,7 @@ inline int c99_snprintf(char* str, size_t size, const char* format, ...)
 	return count;
 }
 
-#		define strdup _strdup
-
+#			define strdup _strdup
 #		endif
 #	endif
 #endif

--- a/windows/freeserf.vcproj
+++ b/windows/freeserf.vcproj
@@ -41,8 +41,8 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="$(ProjectDir)"
-				PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS"
+				AdditionalIncludeDirectories="&quot;$(ProjectDir)&quot;;&quot;$(ProjectDir)\..\src&quot;"
+				PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -117,8 +117,8 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalIncludeDirectories="$(ProjectDir)"
-				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS"
+				AdditionalIncludeDirectories="&quot;$(ProjectDir)&quot;;&quot;$(ProjectDir)\..\src&quot;"
+				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS"
 				RuntimeLibrary="2"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
@@ -206,12 +206,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\data-source-dos.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -230,9 +246,21 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="..\src\freeserf.c"
+				RelativePath="..\src\freeserf.cc"
+				>
+			</File>
+			<File
+				RelativePath="..\src\game-init.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
@@ -242,12 +270,8 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\game-init.c"
-				>
 				<FileConfiguration
-					Name="Debug|Win32"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -266,12 +290,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\gfx.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -290,12 +330,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\interface.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -314,12 +370,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\log.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -338,12 +410,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\minimap.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -362,12 +450,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\notification.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -386,9 +490,21 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="..\src\pathfinder.c"
+				RelativePath="..\src\pathfinder.cc"
+				>
+			</File>
+			<File
+				RelativePath="..\src\player.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
@@ -398,12 +514,8 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\player.c"
-				>
 				<FileConfiguration
-					Name="Debug|Win32"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -422,12 +534,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\pqueue.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -446,12 +574,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\savegame.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -470,12 +614,48 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\serf.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\tpwm.c"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -494,12 +674,28 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="..\src\viewport.c"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -630,11 +826,19 @@
 				>
 			</File>
 			<File
+				RelativePath="..\src\tpwm.h"
+				>
+			</File>
+			<File
 				RelativePath=".\version-vcs.h"
 				>
 			</File>
 			<File
 				RelativePath="..\src\version.h"
+				>
+			</File>
+			<File
+				RelativePath="..\src\video.h"
 				>
 			</File>
 			<File


### PR DESCRIPTION
"There are missing includes in audio-sdlmixer.c and gfx.c."
Maybe it's about SDL*.h?
SDL only requirement and paths for it must be configured in Visual Studio.