### PR TITLE
Fix inventory bug

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -58,7 +58,7 @@ inventory_t::inventory_t(game_t *game, unsigned int index)
 
 void
 inventory_t::push_resource(resource_type_t resource) {
-  resources[resource] += (resources[resource] < 50000) ? 0 : 1;
+  resources[resource] += (resources[resource] < 50000) ? 1 : 0;
 }
 
 void


### PR DESCRIPTION
There was a bug in the function **inventory_t::push_resource** where the operations of the ternary operator were inverted. This meant that when a resource was delivered to the castle, the stock of that resource was not incremented. This pull request should fix that.