### PR TITLE
appveyor: Enable HTTP proxy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ configuration:
   - Release
 
 install:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-http-proxy.ps1'))
+
   # SDL2
   - ps: Start-FileDownload https://libsdl.org/release/SDL2-devel-2.0.3-VC.zip
   - ps: 7z x SDL2-devel-2.0.3-VC.zip -oC:\


### PR DESCRIPTION
I noticed that AppVeyor often fails to build because of a failure to download the SDL zip files. AppVeyor suggests (http://www.appveyor.com/docs/how-to/http-proxy) enabling HTTP proxy to alleviate this.

@wdigger Maybe try this for the PR #216 that keeps failing.