### PR TITLE
serf: Fix bug where serf counters are changed incorrectly

### DIFF
--- a/src/serf.cc
+++ b/src/serf.cc
@@ -290,7 +290,7 @@ serf_t::set_type(serf_type_t new_type) {
 
   /* Register this type as transporter */
   if (new_type == SERF_TRANSPORTER_INVENTORY) new_type = SERF_TRANSPORTER;
-  if (old_type == SERF_TRANSPORTER_INVENTORY) new_type = SERF_TRANSPORTER;
+  if (old_type == SERF_TRANSPORTER_INVENTORY) old_type = SERF_TRANSPORTER;
 
   player_t *player = game->get_player(get_player());
   player->decrease_serf_count(old_type);


### PR DESCRIPTION
Fixes bug in `serf::set_type()` where the type `SERF_TRANSPORTER_INVENTORY` should be counted in the player counter of total serfs as a `SERF_TRANSPORTER`. The bug caused an incorrect update when a serf of the former type was changed to a different type which caused the total `SERF_TRANSPORTER` count to be incorrect.