### PR TITLE
game: Revert to using the random_state_t from save game

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -2269,7 +2269,7 @@ game_t::lose_resource(resource_type_t res) {
 
 uint16_t
 game_t::random_int() {
-  return init_map_rnd.random();
+  return rnd.random();
 }
 
 bool


### PR DESCRIPTION
Revert to the behaviour before 56c30113 when the `game::random_int()` was changed to use the map randomness source to generate random numbers. The game randomness is saved in the save game which guarantees the same game progression after a save game is loaded.