### PR TITLE
Add map terrain enum

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -747,17 +747,20 @@ game_t::road_segment_in_water(map_pos_t pos, dir_t dir) {
 
   switch (dir) {
   case DIR_RIGHT:
-    if (map->type_down(pos) < 4 && map->type_up(map->move_up(pos)) < 4) {
+    if (map->type_down(pos) <= MAP_TERRAIN_WATER_3 &&
+        map->type_up(map->move_up(pos)) <= MAP_TERRAIN_WATER_3) {
       water = 1;
     }
     break;
   case DIR_DOWN_RIGHT:
-    if (map->type_up(pos) < 4 && map->type_down(pos) < 4) {
+    if (map->type_up(pos) <= MAP_TERRAIN_WATER_3 &&
+        map->type_down(pos) <= MAP_TERRAIN_WATER_3) {
       water = 1;
     }
     break;
   case DIR_DOWN:
-    if (map->type_up(pos) < 4 && map->type_down(map->move_left(pos)) < 4) {
+    if (map->type_up(pos) <= MAP_TERRAIN_WATER_3 &&
+        map->type_down(map->move_left(pos)) <= MAP_TERRAIN_WATER_3) {
       water = 1;
     }
     break;
@@ -1055,12 +1058,12 @@ game_t::can_build_flag(map_pos_t pos, const player_t *player) {
   }
 
   /* Check whether cursor is in water */
-  if (map->type_up(pos) < 4 &&
-      map->type_down(pos) < 4 &&
-      map->type_down(map->move_left(pos)) < 4 &&
-      map->type_up(map->move_up_left(pos)) < 4 &&
-      map->type_down(map->move_up_left(pos)) < 4 &&
-      map->type_up(map->move_up(pos)) < 4) {
+  if (map->type_up(pos) <= MAP_TERRAIN_WATER_3 &&
+      map->type_down(pos) <= MAP_TERRAIN_WATER_3 &&
+      map->type_down(map->move_left(pos)) <= MAP_TERRAIN_WATER_3 &&
+      map->type_up(map->move_up_left(pos)) <= MAP_TERRAIN_WATER_3 &&
+      map->type_down(map->move_up_left(pos)) <= MAP_TERRAIN_WATER_3 &&
+      map->type_up(map->move_up(pos)) <= MAP_TERRAIN_WATER_3) {
     return false;
   }
 
@@ -1160,7 +1163,8 @@ game_t::get_leveling_height(map_pos_t pos) {
 }
 
 bool
-game_t::map_types_within(map_pos_t pos, unsigned int low, unsigned int high) {
+game_t::map_types_within(
+    map_pos_t pos, map_terrain_t low, map_terrain_t high) {
   if ((map->type_up(pos) >= low &&
        map->type_up(pos) <= high) &&
       (map->type_down(pos) >= low &&
@@ -1182,13 +1186,13 @@ game_t::map_types_within(map_pos_t pos, unsigned int low, unsigned int high) {
 /* Checks whether a small building is possible at position.*/
 bool
 game_t::can_build_small(map_pos_t pos) {
-  return map_types_within(pos, 4, 7);
+  return map_types_within(pos, MAP_TERRAIN_GRASS_0, MAP_TERRAIN_GRASS_3);
 }
 
 /* Checks whether a mine is possible at position. */
 bool
 game_t::can_build_mine(map_pos_t pos) {
-  return map_types_within(pos, 11, 14);
+  return map_types_within(pos, MAP_TERRAIN_TUNDRA_0, MAP_TERRAIN_SNOW_0);
 }
 
 /* Checks whether a large building is possible at position. */
@@ -1211,12 +1215,12 @@ game_t::can_build_large(map_pos_t pos) {
   }
 
   /* Check if center hexagon is not type grass. */
-  if (map->type_up(pos) != 5 ||
-      map->type_down(pos) != 5 ||
-      map->type_down(map->move_left(pos)) != 5 ||
-      map->type_up(map->move_up_left(pos)) != 5 ||
-      map->type_down(map->move_up_left(pos)) != 5 ||
-      map->type_up(map->move_up(pos)) != 5) {
+  if (map->type_up(pos) != MAP_TERRAIN_GRASS_1 ||
+      map->type_down(pos) != MAP_TERRAIN_GRASS_1 ||
+      map->type_down(map->move_left(pos)) != MAP_TERRAIN_GRASS_1 ||
+      map->type_up(map->move_up_left(pos)) != MAP_TERRAIN_GRASS_1 ||
+      map->type_down(map->move_up_left(pos)) != MAP_TERRAIN_GRASS_1 ||
+      map->type_up(map->move_up(pos)) != MAP_TERRAIN_GRASS_1) {
     return false;
   }
 
@@ -1278,12 +1282,12 @@ game_t::can_player_build(map_pos_t pos, const player_t *player) {
   }
 
   /* Check whether cursor is in water */
-  if (map->type_up(pos) < 4 &&
-      map->type_down(pos) < 4 &&
-      map->type_down(map->move_left(pos)) < 4 &&
-      map->type_up(map->move_up_left(pos)) < 4 &&
-      map->type_down(map->move_up_left(pos)) < 4 &&
-      map->type_up(map->move_up(pos)) < 4) {
+  if (map->type_up(pos) <= MAP_TERRAIN_WATER_3 &&
+      map->type_down(pos) <= MAP_TERRAIN_WATER_3 &&
+      map->type_down(map->move_left(pos)) <= MAP_TERRAIN_WATER_3 &&
+      map->type_up(map->move_up_left(pos)) <= MAP_TERRAIN_WATER_3 &&
+      map->type_down(map->move_up_left(pos)) <= MAP_TERRAIN_WATER_3 &&
+      map->type_up(map->move_up(pos)) <= MAP_TERRAIN_WATER_3) {
     return false;
   }
 

--- a/src/game.h
+++ b/src/game.h
@@ -234,7 +234,7 @@ class game_t : public event_handler_t {
   void remove_road_forwards(map_pos_t pos, dir_t dir);
   bool demolish_road_(map_pos_t pos);
   void build_flag_split_path(map_pos_t pos);
-  bool map_types_within(map_pos_t pos, unsigned int low, unsigned int high);
+  bool map_types_within(map_pos_t pos, map_terrain_t low, map_terrain_t high);
   void flag_remove_player_refs(flag_t *flag);
   bool demolish_flag_(map_pos_t pos);
   bool demolish_building_(map_pos_t pos);

--- a/src/map.cc
+++ b/src/map.cc
@@ -716,16 +716,16 @@ map_t::heights_rebase() {
   }
 }
 
-static int
+static map_terrain_t
 calc_map_type(int h_sum) {
-  if (h_sum < 3) return 0;
-  else if (h_sum < 384) return 5;
-  else if (h_sum < 416) return 6;
-  else if (h_sum < 448) return 11;
-  else if (h_sum < 480) return 12;
-  else if (h_sum < 528) return 13;
-  else if (h_sum < 560) return 14;
-  return 15;
+  if (h_sum < 3) return MAP_TERRAIN_WATER_0;
+  else if (h_sum < 384) return MAP_TERRAIN_GRASS_1;
+  else if (h_sum < 416) return MAP_TERRAIN_GRASS_2;
+  else if (h_sum < 448) return MAP_TERRAIN_TUNDRA_0;
+  else if (h_sum < 480) return MAP_TERRAIN_TUNDRA_1;
+  else if (h_sum < 528) return MAP_TERRAIN_TUNDRA_2;
+  else if (h_sum < 560) return MAP_TERRAIN_SNOW_0;
+  return MAP_TERRAIN_SNOW_1;
 }
 
 /* Set type of map fields based on the height value. */
@@ -777,12 +777,24 @@ map_t::init_types_2() {
                 tiles[pos_].obj = 2;
 
                 int flags = 0;
-                if (tiles[pos_].type & 0xc) flags |= 3;
-                if (tiles[pos_].type & 0xc0) flags |= 6;
-                if (tiles[move_left(pos_)].type & 0xc) flags |= 0xc;
-                if (tiles[move_up_left(pos_)].type & 0xc0) flags |= 0x18;
-                if (tiles[move_up_left(pos_)].type & 0xc) flags |= 0x30;
-                if (tiles[move_up(pos_)].type & 0xc0) flags |= 0x21;
+                if (type_down(pos_) >= MAP_TERRAIN_GRASS_0) {
+                  flags |= 3;
+                }
+                if (type_up(pos_) >= MAP_TERRAIN_GRASS_0) {
+                  flags |= 6;
+                }
+                if (type_down(move_left(pos_)) >= MAP_TERRAIN_GRASS_0) {
+                  flags |= 0xc;
+                }
+                if (type_up(move_up_left(pos_)) >= MAP_TERRAIN_GRASS_0) {
+                  flags |= 0x18;
+                }
+                if (type_down(move_up_left(pos_)) >= MAP_TERRAIN_GRASS_0) {
+                  flags |= 0x30;
+                }
+                if (type_up(move_up(pos_)) >= MAP_TERRAIN_GRASS_0) {
+                  flags |= 0x21;
+                }
 
                 for (int d = DIR_RIGHT; d <= DIR_UP; d++) {
                   if (BIT_TEST(flags, d)) {
@@ -834,8 +846,8 @@ map_t::heights_rescale() {
 }
 
 void
-map_t::init_types_shared_sub(unsigned int old, unsigned int seed,
-                             unsigned int new_) {
+map_t::init_types_shared_sub(map_terrain_t old, map_terrain_t seed,
+                             map_terrain_t new_) {
   for (unsigned int y = 0; y < rows; y++) {
     for (unsigned int x = 0; x < cols; x++) {
       map_pos_t pos_ = pos(x, y);
@@ -877,14 +889,18 @@ map_t::init_types_shared_sub(unsigned int old, unsigned int seed,
 
 void
 map_t::init_lakes() {
-  init_types_shared_sub(0, 5, 3);
-  init_types_shared_sub(0, 3, 2);
-  init_types_shared_sub(0, 2, 1);
+  init_types_shared_sub(
+    MAP_TERRAIN_WATER_0, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_WATER_3);
+  init_types_shared_sub(
+    MAP_TERRAIN_WATER_0, MAP_TERRAIN_WATER_3, MAP_TERRAIN_WATER_2);
+  init_types_shared_sub(
+    MAP_TERRAIN_WATER_0, MAP_TERRAIN_WATER_2, MAP_TERRAIN_WATER_1);
 }
 
 void
 map_t::init_types4() {
-  init_types_shared_sub(5, 3, 4);
+  init_types_shared_sub(
+    MAP_TERRAIN_GRASS_1, MAP_TERRAIN_WATER_3, MAP_TERRAIN_GRASS_0);
 }
 
 /* Use spiral pattern to lookup a new position based on col, row. */
@@ -895,34 +911,50 @@ map_t::lookup_pattern(int col, int row, int index) {
 
 int
 map_t::init_desert_sub1(map_pos_t pos_) {
-  int type_d = type_down(pos_);
-  int type_u = type_up(pos_);
+  map_terrain_t type_d = type_down(pos_);
+  map_terrain_t type_u = type_up(pos_);
 
-  if (type_d != 5 && type_d != 10) return -1;
-  if (type_u != 5 && type_u != 10) return -1;
+  if (type_d != MAP_TERRAIN_GRASS_1 && type_d != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
+  if (type_u != MAP_TERRAIN_GRASS_1 && type_u != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
 
   type_d = type_down(move_left(pos_));
-  if (type_d != 5 && type_d != 10) return -1;
+  if (type_d != MAP_TERRAIN_GRASS_1 && type_d != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
 
   type_d = type_down(move_down(pos_));
-  if (type_d != 5 && type_d != 0xa) return -1;
+  if (type_d != MAP_TERRAIN_GRASS_1 && type_d != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
 
   return 0;
 }
 
 int
 map_t::init_desert_sub2(map_pos_t pos_) {
-  int type_d = type_down(pos_);
-  int type_u = type_up(pos_);
+  map_terrain_t type_d = type_down(pos_);
+  map_terrain_t type_u = type_up(pos_);
 
-  if (type_d != 5 && type_d != 10) return -1;
-  if (type_u != 5 && type_u != 10) return -1;
+  if (type_d != MAP_TERRAIN_GRASS_1 && type_d != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
+  if (type_u != MAP_TERRAIN_GRASS_1 && type_u != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
 
   type_u = type_up(move_right(pos_));
-  if (type_u != 5 && type_u != 10) return -1;
+  if (type_u != MAP_TERRAIN_GRASS_1 && type_u != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
 
   type_u = type_up(move_up(pos_));
-  if (type_u != 5 && type_u != 10) return -1;
+  if (type_u != MAP_TERRAIN_GRASS_1 && type_u != MAP_TERRAIN_DESERT_2) {
+    return -1;
+  }
 
   return 0;
 }
@@ -935,16 +967,21 @@ map_t::init_desert() {
       int col, row;
       map_pos_t rnd_pos = get_rnd_coord(&col, &row);
 
-      if (type_up(rnd_pos) == 5 &&
-          type_down(rnd_pos) == 5) {
+      if (type_up(rnd_pos) == MAP_TERRAIN_GRASS_1 &&
+          type_down(rnd_pos) == MAP_TERRAIN_GRASS_1) {
         for (int index = 255; index >= 0; index--) {
           map_pos_t pos = lookup_pattern(col, row, index);
 
           int r = init_desert_sub1(pos);
-          if (r == 0) tiles[pos].type = (10 << 4) | (tiles[pos].type & 0xf);
+          if (r == 0) {
+            tiles[pos].type =
+              (MAP_TERRAIN_DESERT_2 << 4) | (tiles[pos].type & 0xf);
+          }
 
           r = init_desert_sub2(pos);
-          if (r == 0) tiles[pos].type = (tiles[pos].type & 0xf0) | 10;
+          if (r == 0) {
+            tiles[pos].type = (tiles[pos].type & 0xf0) | MAP_TERRAIN_DESERT_2;
+          }
         }
         break;
       }
@@ -957,11 +994,15 @@ map_t::init_desert_2_sub() {
   for (unsigned int y = 0; y < rows; y++) {
     for (unsigned int x = 0; x < cols; x++) {
       map_pos_t pos_ = pos(x, y);
-      int type_d = type_down(pos_);
-      int type_u = type_up(pos_);
+      map_terrain_t type_d = type_down(pos_);
+      map_terrain_t type_u = type_up(pos_);
 
-      if (type_d >= 7 && type_d < 10) type_d = 5;
-      if (type_u >= 7 && type_u < 10) type_u = 5;
+      if (type_d >= MAP_TERRAIN_GRASS_3 && type_d <= MAP_TERRAIN_DESERT_1) {
+        type_d = MAP_TERRAIN_GRASS_1;
+      }
+      if (type_u >= MAP_TERRAIN_GRASS_3 && type_u <= MAP_TERRAIN_DESERT_1) {
+        type_u = MAP_TERRAIN_GRASS_1;
+      }
 
       tiles[pos_].type = (type_u << 4) | type_d;
     }
@@ -970,15 +1011,21 @@ map_t::init_desert_2_sub() {
 
 void
 map_t::init_desert_2() {
-  init_types_shared_sub(10, 5, 7);
-  init_types_shared_sub(10, 7, 8);
-  init_types_shared_sub(10, 8, 9);
+  init_types_shared_sub(
+    MAP_TERRAIN_DESERT_2, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3);
+  init_types_shared_sub(
+    MAP_TERRAIN_DESERT_2, MAP_TERRAIN_GRASS_3, MAP_TERRAIN_DESERT_0);
+  init_types_shared_sub(
+    MAP_TERRAIN_DESERT_2, MAP_TERRAIN_DESERT_0, MAP_TERRAIN_DESERT_1);
 
   init_desert_2_sub();
 
-  init_types_shared_sub(5, 10, 9);
-  init_types_shared_sub(5, 9, 8);
-  init_types_shared_sub(5, 8, 7);
+  init_types_shared_sub(
+    MAP_TERRAIN_GRASS_1, MAP_TERRAIN_DESERT_2, MAP_TERRAIN_DESERT_1);
+  init_types_shared_sub(
+    MAP_TERRAIN_GRASS_1, MAP_TERRAIN_DESERT_1, MAP_TERRAIN_DESERT_0);
+  init_types_shared_sub(
+    MAP_TERRAIN_GRASS_1, MAP_TERRAIN_DESERT_0, MAP_TERRAIN_GRASS_3);
 }
 
 /* Put crosses on top of mountains. */
@@ -1005,9 +1052,10 @@ map_t::init_crosses() {
    between min and max. Return -1 if not all triangles are
    in this range. */
 int
-map_t::init_objects_shared_sub1(map_pos_t pos_, int min, int max) {
-  int type_d = type_down(pos_);
-  int type_u = type_up(pos_);
+map_t::init_objects_shared_sub1(
+    map_pos_t pos_, map_terrain_t min, map_terrain_t max) {
+  map_terrain_t type_d = type_down(pos_);
+  map_terrain_t type_u = type_up(pos_);
 
   if (type_d < min || type_d >= max) return -1;
   if (type_u < min || type_u >= max) return -1;
@@ -1040,8 +1088,8 @@ map_t::lookup_rnd_pattern(int col, int row, int mask) {
 
 void
 map_t::init_objects_shared(int num_clusters, int objs_in_cluster, int pos_mask,
-                           int type_min, int type_max, int obj_base,
-                           int obj_mask) {
+                           map_terrain_t type_min, map_terrain_t type_max,
+                           int obj_base, int obj_mask) {
   for (int i = 0; i < num_clusters; i++) {
     for (int try_ = 0; try_ < 100; try_++) {
       int col, row;
@@ -1064,80 +1112,110 @@ map_t::init_objects_shared(int num_clusters, int objs_in_cluster, int pos_mask,
 void
 map_t::init_trees_1() {
   /* Add either tree or pine. */
-  init_objects_shared(regions << 3, 10, 0xff, 5, 7, MAP_OBJ_TREE_0, 0xf);
+  init_objects_shared(
+    regions << 3, 10, 0xff, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_TREE_0, 0xf);
 }
 
 void
 map_t::init_trees_2() {
   /* Add only trees. */
-  init_objects_shared(regions, 45, 0x3f, 5, 7, MAP_OBJ_TREE_0, 0x7);
+  init_objects_shared(
+    regions, 45, 0x3f, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_TREE_0, 0x7);
 }
 
 void
 map_t::init_trees_3() {
   /* Add only pines. */
-  init_objects_shared(regions, 30, 0x3f, 4, 7, MAP_OBJ_PINE_0, 0x7);
+  init_objects_shared(
+    regions, 30, 0x3f, MAP_TERRAIN_GRASS_0, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_PINE_0, 0x7);
 }
 
 void
 map_t::init_trees_4() {
   /* Add either tree or pine. */
-  init_objects_shared(regions, 20, 0x7f, 5, 7, MAP_OBJ_TREE_0, 0xf);
+  init_objects_shared(
+    regions, 20, 0x7f, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_TREE_0, 0xf);
 }
 
 void
 map_t::init_stone_1() {
-  init_objects_shared(regions, 40, 0x3f, 5, 7, MAP_OBJ_STONE_0, 0x7);
+  init_objects_shared(
+    regions, 40, 0x3f, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_STONE_0, 0x7);
 }
 
 void
 map_t::init_stone_2() {
-  init_objects_shared(regions, 15, 0xff, 5, 7, MAP_OBJ_STONE_0, 0x7);
+  init_objects_shared(
+    regions, 15, 0xff, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_STONE_0, 0x7);
 }
 
 void
 map_t::init_dead_trees() {
-  init_objects_shared(regions, 2, 0xff, 5, 7, MAP_OBJ_DEAD_TREE, 0);
+  init_objects_shared(
+    regions, 2, 0xff, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_DEAD_TREE, 0);
 }
 
 void
 map_t::init_large_boulders() {
-  init_objects_shared(regions, 6, 0xff, 5, 7, MAP_OBJ_SANDSTONE_0, 0x1);
+  init_objects_shared(
+    regions, 6, 0xff, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_SANDSTONE_0, 0x1);
 }
 
 void
 map_t::init_water_trees() {
-  init_objects_shared(regions, 50, 0x7f, 2, 4, MAP_OBJ_WATER_TREE_0, 0x3);
+  init_objects_shared(
+    regions, 50, 0x7f, MAP_TERRAIN_WATER_2, MAP_TERRAIN_GRASS_0,
+    MAP_OBJ_WATER_TREE_0, 0x3);
 }
 
 void
 map_t::init_stubs() {
-  init_objects_shared(regions, 5, 0xff, 5, 7, MAP_OBJ_STUB, 0);
+  init_objects_shared(
+    regions, 5, 0xff, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_STUB, 0);
 }
 
 void
 map_t::init_small_boulders() {
-  init_objects_shared(regions, 10, 0xff, 5, 7, MAP_OBJ_STONE, 0x1);
+  init_objects_shared(
+    regions, 10, 0xff, MAP_TERRAIN_GRASS_1, MAP_TERRAIN_GRASS_3,
+    MAP_OBJ_STONE, 0x1);
 }
 
 void
 map_t::init_cadavers() {
-  init_objects_shared(regions, 2, 0xf, 10, 11, MAP_OBJ_CADAVER_0, 0x1);
+  init_objects_shared(
+    regions, 2, 0xf, MAP_TERRAIN_DESERT_2, MAP_TERRAIN_TUNDRA_0,
+    MAP_OBJ_CADAVER_0, 0x1);
 }
 
 void
 map_t::init_cacti() {
-  init_objects_shared(regions, 6, 0x7f, 8, 11, MAP_OBJ_CACTUS_0, 0x1);
+  init_objects_shared(
+    regions, 6, 0x7f, MAP_TERRAIN_DESERT_0, MAP_TERRAIN_TUNDRA_0,
+    MAP_OBJ_CACTUS_0, 0x1);
 }
 
 void
 map_t::init_water_stones() {
-  init_objects_shared(regions, 8, 0x7f, 0, 3, MAP_OBJ_WATER_STONE_0, 0x1);
+  init_objects_shared(
+    regions, 8, 0x7f, MAP_TERRAIN_WATER_0, MAP_TERRAIN_WATER_3,
+    MAP_OBJ_WATER_STONE_0, 0x1);
 }
 
 void
 map_t::init_palms() {
-  init_objects_shared(regions, 6, 0x3f, 10, 11, MAP_OBJ_PALM_0, 0x3);
+  init_objects_shared(
+    regions, 6, 0x3f, MAP_TERRAIN_DESERT_2, MAP_TERRAIN_TUNDRA_0,
+    MAP_OBJ_PALM_0, 0x3);
 }
 
 void
@@ -1156,7 +1234,7 @@ map_t::init_resources_shared_sub(int iters, int col, int row, int *index,
 
 void
 map_t::init_resources_shared(int num_clusters, ground_deposit_t type,
-                             int min, int max) {
+                             map_terrain_t min, map_terrain_t max) {
   for (int i = 0; i < num_clusters; i++) {
     for (int try_ = 0; try_ < 100; try_++) {
       int col, row;
@@ -1195,10 +1273,18 @@ map_t::init_resources_shared(int num_clusters, ground_deposit_t type,
 /* Initialize resources in the ground. */
 void
 map_t::init_resources() {
-  init_resources_shared(regions * 9, GROUND_DEPOSIT_COAL, 11, 15);
-  init_resources_shared(regions * 4, GROUND_DEPOSIT_IRON, 11, 15);
-  init_resources_shared(regions * 2, GROUND_DEPOSIT_GOLD, 11, 15);
-  init_resources_shared(regions * 2, GROUND_DEPOSIT_STONE, 11, 15);
+  init_resources_shared(
+    regions * 9, GROUND_DEPOSIT_COAL,
+    MAP_TERRAIN_TUNDRA_0, MAP_TERRAIN_SNOW_1);
+  init_resources_shared(
+    regions * 4, GROUND_DEPOSIT_IRON,
+    MAP_TERRAIN_TUNDRA_0, MAP_TERRAIN_SNOW_1);
+  init_resources_shared(
+    regions * 2, GROUND_DEPOSIT_GOLD,
+    MAP_TERRAIN_TUNDRA_0, MAP_TERRAIN_SNOW_1);
+  init_resources_shared(
+    regions * 2, GROUND_DEPOSIT_STONE,
+    MAP_TERRAIN_TUNDRA_0, MAP_TERRAIN_SNOW_1);
 }
 
 void
@@ -1739,17 +1825,20 @@ map_t::road_segment_in_water(map_pos_t pos_, dir_t dir) {
 
   switch (dir) {
     case DIR_RIGHT:
-      if (type_down(pos_) < 4 && type_up(move_up(pos_)) < 4) {
+      if (type_down(pos_) <= MAP_TERRAIN_WATER_3 &&
+          type_up(move_up(pos_)) <= MAP_TERRAIN_WATER_3) {
         water = true;
       }
       break;
     case DIR_DOWN_RIGHT:
-      if (type_up(pos_) < 4 && type_down(pos_) < 4) {
+      if (type_up(pos_) <= MAP_TERRAIN_WATER_3 &&
+          type_down(pos_) <= MAP_TERRAIN_WATER_3) {
         water = true;
       }
       break;
     case DIR_DOWN:
-      if (type_up(pos_) < 4 && type_down(move_left(pos_)) < 4) {
+      if (type_up(pos_) <= MAP_TERRAIN_WATER_3 &&
+          type_down(move_left(pos_)) <= MAP_TERRAIN_WATER_3) {
         water = true;
       }
       break;
@@ -1772,7 +1861,7 @@ map_t::del_change_handler(update_map_height_handler_t *handler) {
 }
 
 bool
-map_t::types_within(map_pos_t pos, unsigned int low, unsigned int high) {
+map_t::types_within(map_pos_t pos, map_terrain_t low, map_terrain_t high) {
   if ((type_up(pos) >= low &&
        type_up(pos) <= high) &&
       (type_down(pos) >= low &&

--- a/src/map.h
+++ b/src/map.h
@@ -485,8 +485,8 @@ class map_t {
   void init_desert_2_sub();
   void init_desert_2();
   void init_crosses();
-  int init_objects_shared_sub1(map_pos_t pos, map_terrain_t min,
-                               map_terrain_t max);
+  bool hexagon_types_in_range(map_pos_t pos, map_terrain_t min,
+                              map_terrain_t max);
   map_pos_t lookup_rnd_pattern(int col, int row, int mask);
   void init_objects_shared(int num_clusters, int objs_in_cluster, int pos_mask,
                            map_terrain_t type_min, map_terrain_t type_max,

--- a/src/player.cc
+++ b/src/player.cc
@@ -355,8 +355,8 @@ player_t::available_knights_at_pos(map_pos_t pos, int index_, int dist) {
   const int min_level_fortress[] = { 1, 3, 6, 9, 12 };
 
   if (game->get_map()->get_owner(pos) != index ||
-      game->get_map()->type_up(pos) < 4 ||
-      game->get_map()->type_down(pos) < 4 ||
+      game->get_map()->type_up(pos) <= MAP_TERRAIN_WATER_3 ||
+      game->get_map()->type_down(pos) <= MAP_TERRAIN_WATER_3 ||
       game->get_map()->get_obj(pos) < MAP_OBJ_SMALL_BUILDING ||
       game->get_map()->get_obj(pos) > MAP_OBJ_CASTLE) {
     return index_;

--- a/src/viewport.cc
+++ b/src/viewport.cc
@@ -88,7 +88,7 @@ viewport_t::draw_triangle_up(int x, int y, int m, int left, int right,
   int mask = 4 + m - left + 9*(4 + m - right);
   assert(tri_mask[mask] >= 0);
 
-  int type = map->type_up(map->move_up(pos));
+  map_terrain_t type = map->type_up(map->move_up(pos));
   int index = (type << 3) | tri_mask[mask];
   assert(index < 128);
 
@@ -384,7 +384,8 @@ viewport_t::draw_path_segment(int x, int y, map_pos_t pos, dir_t dir) {
   int h2 = map->get_height(map->move(pos, dir));
   int h_diff = h1 - h2;
 
-  int t1, t2, h3, h4, h_diff_2;
+  map_terrain_t t1, t2;
+  int h3, h4, h_diff_2;
 
   switch (dir) {
   case DIR_RIGHT:
@@ -419,7 +420,7 @@ viewport_t::draw_path_segment(int x, int y, map_pos_t pos, dir_t dir) {
 
   int mask = h_diff + 4 + dir*9;
   int sprite = 0;
-  int type = std::max(t1, t2);
+  map_terrain_t type = std::max(t1, t2);
 
   if (h_diff_2 > 4) {
     sprite = 0;
@@ -429,11 +430,11 @@ viewport_t::draw_path_segment(int x, int y, map_pos_t pos, dir_t dir) {
     sprite = 2;
   }
 
-  if (type < 4) {
+  if (type <= MAP_TERRAIN_WATER_3) {
     sprite = 9;
-  } else if (type > 13) {
+  } else if (type >= MAP_TERRAIN_SNOW_0) {
     sprite += 6;
-  } else if (type > 7) {
+  } else if (type >= MAP_TERRAIN_DESERT_0) {
     sprite += 3;
   }
 
@@ -448,7 +449,8 @@ viewport_t::draw_border_segment(int x, int y, map_pos_t pos, dir_t dir) {
   int h2 = map->get_height(map->move(pos, dir));
   int h_diff = h2 - h1;
 
-  int t1, t2, h3, h4, h_diff_2;
+  map_terrain_t t1, t2;
+  int h3, h4, h_diff_2;
 
   switch (dir) {
   case DIR_RIGHT:
@@ -484,7 +486,7 @@ viewport_t::draw_border_segment(int x, int y, map_pos_t pos, dir_t dir) {
   }
 
   int sprite = 0;
-  int type = std::max(t1, t2);
+  map_terrain_t type = std::max(t1, t2);
 
   if (h_diff_2 > 1) {
     sprite = 0;
@@ -494,11 +496,11 @@ viewport_t::draw_border_segment(int x, int y, map_pos_t pos, dir_t dir) {
     sprite = 2;
   }
 
-  if (type < 4) {
+  if (type <= MAP_TERRAIN_WATER_3) {
     sprite = 9; /* Bouy */
-  } else if (type > 13) {
+  } else if (type >= MAP_TERRAIN_SNOW_0) {
     sprite += 6;
-  } else if (type > 7) {
+  } else if (type >= MAP_TERRAIN_DESERT_0) {
     sprite += 3;
   }
 
@@ -1138,9 +1140,10 @@ viewport_t::draw_water_waves(map_pos_t pos, int x, int y) {
   int sprite = DATA_MAP_WAVES_BASE +
                (((pos ^ 5) + (interface->get_game()->get_tick() >> 3)) & 0xf);
 
-  if (map->type_down(pos) < 4 && map->type_up(pos) < 4) {
+  if (map->type_down(pos) <= MAP_TERRAIN_WATER_3 &&
+      map->type_up(pos) <= MAP_TERRAIN_WATER_3) {
     frame->draw_waves_sprite(x - 16, y, 0, sprite);
-  } else if (map->type_down(pos) < 4) {
+  } else if (map->type_down(pos) <= MAP_TERRAIN_WATER_3) {
     int mask = DATA_MAP_MASK_DOWN_BASE + 40;
     frame->draw_waves_sprite(x, y + 16, mask, sprite);
   } else {
@@ -1154,7 +1157,8 @@ viewport_t::draw_water_waves_row(map_pos_t pos, int y_base, int cols,
                                  int x_base) {
   for (int i = 0; i < cols; i++, x_base += MAP_TILE_WIDTH,
        pos = map->move_right(pos)) {
-    if (map->type_up(pos) < 4 || map->type_down(pos) < 4) {
+    if (map->type_up(pos) <= MAP_TERRAIN_WATER_3 ||
+        map->type_down(pos) <= MAP_TERRAIN_WATER_3) {
       /*player->water_in_view += 1;*/
       draw_water_waves(pos, x_base, y_base);
     }


### PR DESCRIPTION
Add `map_terrain_t` enum for `type_up` and `type_down` map tile fields based on the documentation in the last PR.

Second commit renames a map generator method and changes how the map terrain type range is provided.