### PR TITLE
appveyor: Cache SDL2 and SDL2_mixer downloads

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,24 +8,33 @@ configuration:
   - Debug
   - Release
 
+cache:
+  - C:\sdl_root
+
 install:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-http-proxy.ps1'))
 
   # SDL2
   - ps: |
       $SDL_VERSION = "2.0.4"
-      Start-FileDownload https://libsdl.org/release/SDL2-devel-$SDL_VERSION-VC.zip
-      7z x SDL2-devel-$SDL_VERSION-VC.zip -oC:\
-      $env:SDL2_INCLUDE = "C:\SDL2-$SDL_VERSION\include"
-      $env:SDL2_LIB = "C:\SDL2-$SDL_VERSION\lib"
+      $SDL_PREFIX = "C:\sdl_root\SDL2-$SDL_VERSION"
+      if (!(Test-Path -Path $SDL_PREFIX)) {
+        Start-FileDownload https://libsdl.org/release/SDL2-devel-$SDL_VERSION-VC.zip
+        7z x SDL2-devel-$SDL_VERSION-VC.zip -oC:\sdl_root\
+        $env:SDL2_INCLUDE = "$SDL_PREFIX\include"
+        $env:SDL2_LIB = "$SDL_PREFIX\lib"
+      }
 
   # SDL2_mixer
   - ps: |
       $SDL_MIXER_VERSION = "2.0.1"
-      Start-FileDownload https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-$SDL_MIXER_VERSION-VC.zip
-      7z x SDL2_mixer-devel-$SDL_MIXER_VERSION-VC.zip -oC:\
-      $env:SDL2_MIXER_INCLUDE = "C:\SDL2_mixer-$SDL_MIXER_VERSION\include"
-      $env:SDL2_MIXER_LIB = "C:\SDL2_mixer-$SDL_MIXER_VERSION\lib"
+      $SDL_MIXER_PREFIX = "C:\sdl_root\SDL2_mixer-$SDL_MIXER_VERSION"
+      if (!(Test-Path -Path $SDL_MIXER_PREFIX)) {
+        Start-FileDownload https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-$SDL_MIXER_VERSION-VC.zip
+        7z x SDL2_mixer-devel-$SDL_MIXER_VERSION-VC.zip -oC:\sdl_root\
+        $env:SDL2_MIXER_INCLUDE = "$SDL_MIXER_PREFIX\include"
+        $env:SDL2_MIXER_LIB = "$SDL_MIXER_PREFIX\lib"
+      }
 
 build_script:
   - msbuild windows\freeserf.sln


### PR DESCRIPTION
Cache is not saved in pull requests so it is not possible to actually test if this works until it is merged.