### PR TITLE
map: Fix typos in Road method names

### DIFF
--- a/src/interface.cc
+++ b/src/interface.cc
@@ -482,12 +482,12 @@ Interface::build_road_end() {
    construction, and 1 if this segment completed the path. */
 int
 Interface::build_road_segment(Direction dir) {
-  if (!building_road.is_extandable()) {
+  if (!building_road.is_extendable()) {
     /* Max length reached */
     return -1;
   }
 
-  building_road.extand(dir);
+  building_road.extend(dir);
 
   MapPos dest;
   int r = game->can_build_road(building_road, player, &dest, NULL);

--- a/src/map.cc
+++ b/src/map.cc
@@ -1076,7 +1076,7 @@ Road::is_undo(Direction dir) const {
 }
 
 bool
-Road::extand(Direction dir) {
+Road::extend(Direction dir) {
   if (begin == bad_map_pos) {
     return false;
   }

--- a/src/map.h
+++ b/src/map.h
@@ -92,10 +92,10 @@ class Road {
   Dirs get_dirs() const { return dirs; }
   size_t get_length() const { return dirs.size(); }
   Direction get_last() const { return dirs.back(); }
-  bool is_extandable() const { return (dirs.size() < max_length); }
+  bool is_extendable() const { return (dirs.size() < max_length); }
   bool is_valid_extension(Map *map, Direction dir) const;
   bool is_undo(Direction dir) const;
-  bool extand(Direction dir);
+  bool extend(Direction dir);
   bool undo();
   MapPos get_end(Map *map) const;
 };

--- a/src/pathfinder.cc
+++ b/src/pathfinder.cc
@@ -123,7 +123,7 @@ pathfinder_map(Map *map, MapPos start, MapPos end) {
       std::list<Direction> dirs;
       while (node->parent != NULL) {
         Direction dir = node->dir;
-        solution.extand(DIR_REVERSE(dir));
+        solution.extend(DIR_REVERSE(dir));
         node = node->parent;
       }
 


### PR DESCRIPTION
`extand` -> `extend`, `is_extandable` -> `is_extendable`