### PR TITLE
Map bugs

### DIFF
--- a/src/map-generator.cc
+++ b/src/map-generator.cc
@@ -990,7 +990,7 @@ ClassicMapGenerator::init_resources_shared(
       int col, row;
       MapPos pos = map.get_rnd_coord(&col, &row, &rnd);
 
-      if (hexagon_types_in_range(pos, min, max) == 0) {
+      if (hexagon_types_in_range(pos, min, max)) {
         int index = 0;
         int amount = 8 + (random_int() & 0xc);
         init_resources_shared_sub(1, col, row, &index, amount, type);


### PR DESCRIPTION
Fixes two map bugs in the mission map generator that caused the resulting map to diverge from the original game maps. The first bug is a regression from a couple of years ago but it only caused a minor difference in the map objects. The other regression was accidentally introduced when the map generator was moved to a separate class. This caused the mineral deposits to be incorrectly initialized.