### PR TITLE
inventory: Fix typos in method names

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -387,7 +387,7 @@ Inventory::specialize_free_serf(Serf::Type type) {
 }
 
 size_t
-Inventory::serf_potencial_count(Serf::Type type) {
+Inventory::serf_potential_count(Serf::Type type) {
   size_t count = generic_count;
 
   if (res_needed[type*2] != Resource::TypeNone) {

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -81,7 +81,7 @@ class Inventory : public GameObject {
   bool have_any_out_mode() { return ((res_dir & 0x0A) != 0); }
 
   int get_serf_queue_length() { return serfs_out; }
-  void sers_away() { serfs_out--; }
+  void serf_away() { serfs_out--; }
   bool call_out_serf(Serf *serf);
   Serf *call_out_serf(Serf::Type type);
   bool call_internal(Serf *serf);
@@ -121,7 +121,7 @@ class Inventory : public GameObject {
   Serf *spawn_serf_generic();
   bool specialize_serf(Serf *serf, Serf::Type type);
   Serf *specialize_free_serf(Serf::Type type);
-  size_t serf_potencial_count(Serf::Type type);
+  size_t serf_potential_count(Serf::Type type);
 
   void serf_idle_in_stock(Serf *serf);
   void knight_training(Serf *serf, int p);

--- a/src/player.cc
+++ b/src/player.cc
@@ -1002,7 +1002,7 @@ Player::get_stats_serfs_potential() {
     Inventory *inventory = *i;
     if (inventory->free_serf_count() > 0) {
       for (int i = 0; i < 27; i++) {
-        res[(Serf::Type)i] += inventory->serf_potencial_count((Serf::Type)i);
+        res[(Serf::Type)i] += inventory->serf_potential_count((Serf::Type)i);
       }
     }
   }

--- a/src/serf.cc
+++ b/src/serf.cc
@@ -2398,7 +2398,7 @@ Serf::handle_serf_ready_to_leave_inventory_state() {
 
   Inventory *inventory =
                       game->get_inventory(s.ready_to_leave_inventory.inv_index);
-  inventory->sers_away();
+  inventory->serf_away();
 
   Serf::State next_state = StateWalking;
   if (s.ready_to_leave_inventory.mode == -3) {


### PR DESCRIPTION
"sers_away" -> "serf_away", "serf_potencial_count" -> "serf_potential_count"