### PR TITLE
Fix regression causing all knights to be instantly promoted

### DIFF
--- a/src/serf.cc
+++ b/src/serf.cc
@@ -901,7 +901,7 @@ Serf::switch_waiting(Direction dir) {
 
 int
 Serf::train_knight(int p) {
-  int delta = game->get_tick() - tick;
+  uint16_t delta = game->get_tick() - tick;
   tick = game->get_tick();
   counter -= delta;
 


### PR DESCRIPTION
Fix regression introduced in d23e43a which changed the delta variable in `Serf::train_knight()` from uint16_t to int. This change meant that when the game tick counter (an unsigned int) became larger than 0x10000 the delta in `train_knight()` would always be >= 0x10000. This resulted in the training loop running more than 10 times for every update step for every knight.