### PR TITLE
Run cpplint on test program source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ install:
   - export CPPLINT_PATH="$PWD/styleguide/cpplint"
 
 script:
-  - $CPPLINT_PATH/cpplint.py ./src/*.cc ./src/*.h ./windows/*.cc ./windows/*.h
+  - $CPPLINT_PATH/cpplint.py ./src/*.cc ./src/*.h ./tests/*.cc ./windows/*.cc ./windows/*.h
   - ./bootstrap && ./configure --enable-sdl2-mixer
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then make dist-osx; else make -j5 distcheck; fi

--- a/tests/test_map.cc
+++ b/tests/test_map.cc
@@ -1,3 +1,23 @@
+/*
+ * test_map.cc - TAP test for classic mission map generator
+ *
+ * Copyright (C) 2016  Jon Lund Steffensen <jonlst@gmail.com>
+ *
+ * This file is part of freeserf.
+ *
+ * freeserf is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * freeserf is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with freeserf.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
Fixes a suggestion about adding a copyright header to `test_map.cc`, then includes `test_map.cc` in the files checked by cpplint on Travis CI.