### PR TITLE
Fix regression causing incorrect land owner

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -398,9 +398,10 @@ class Map {
     game_tiles[pos].paths &= ~BIT(dir); }
 
   bool has_owner(MapPos pos) const { return (game_tiles[pos].owner != 0); }
-  unsigned int get_owner(MapPos pos) const { return game_tiles[pos].owner; }
+  unsigned int get_owner(MapPos pos) const {
+    return game_tiles[pos].owner - 1; }
   void set_owner(MapPos pos, unsigned int _owner) {
-    game_tiles[pos].owner = _owner; }
+    game_tiles[pos].owner = _owner + 1; }
   void del_owner(MapPos pos) { game_tiles[pos].owner = 0; }
   unsigned int get_height(MapPos pos) const {
     return landscape_tiles[pos].height; }


### PR DESCRIPTION
Fix regression introduced in 5862cb3 where owner == 0 was changed to mean that the land has no owner. This resulted in the first player (player 0) not being able to own any land. Fixed by incrementing the stored player number by one such that 0 indicates no owner, player 0 is indicated by 1, and so on.