### PR TITLE
Add test program for saving and loading game

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,9 @@
 
 # freeserf
 bin_PROGRAMS = freeserf
-noinst_PROGRAMS = tests/test_map
+noinst_PROGRAMS = \
+	tests/test_map \
+	tests/test_save_game
 
 GAME_SOURCES = \
 	src/building.cc src/building.h \
@@ -57,6 +59,10 @@ tests_test_map_SOURCES = \
 	tests/test_map.cc \
 	$(GAME_SOURCES)
 
+tests_test_save_game_SOURCES = \
+	tests/test_save_game.cc \
+	$(GAME_SOURCES)
+
 AM_CFLAGS = $(SDL2_CFLAGS) -I$(top_builddir)/src
 AM_CXXFLAGS = $(SDL2_CFLAGS) -I$(top_builddir)/src
 freeserf_LDADD = $(SDL2_LIBS) $(SDL2_CFLAGS) -lm
@@ -78,7 +84,9 @@ CLEANFILES = $(VCS_VERSION_FILE)
 # Tests
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/tap-driver.sh
-TESTS = tests/test_map
+TESTS = \
+	tests/test_map \
+	tests/test_save_game
 
 EXTRA_DIST = \
 	README.md HACKING.md \

--- a/src/freeserf.cc
+++ b/src/freeserf.cc
@@ -22,6 +22,8 @@
 #include "src/freeserf.h"
 
 #include <ctime>
+#include <fstream>
+#include <iostream>
 #include <string>
 
 #ifdef HAVE_CONFIG_H
@@ -92,12 +94,12 @@ save_game(int autosave, Game *game) {
   /* TODO Possibly use PathCleanupSpec() when building for windows platform. */
   strreplace(name, "\\/:*?\"<>| ", '_');
 
-  FILE *f = fopen(name, "wb");
-  if (f == NULL) return false;
+  std::ofstream os(name, std::ios::binary);
+  if (!os.is_open()) return false;
 
-  if (!save_text_state(f, game)) return false;
+  if (!save_text_state(&os, game)) return false;
 
-  fclose(f);
+  os.close();
 
   Log::Info["main"] << "Game saved to `" << name << "'.";
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -2233,8 +2233,6 @@ Game::load_mission_map(int level) {
     init_map_data(generator);
   }
 
-  allocate_objects();
-
   /* Initialize player and build initial castle */
   for (int i = 0; i < GAME_MAX_PLAYER_COUNT; i++) {
     size_t face = (i == 0) ? 12 : mission->player[i].face;
@@ -2268,8 +2266,6 @@ Game::load_random_map(int size, const Random &rnd) {
     generator.generate();
     init_map_data(generator);
   }
-
-  allocate_objects();
 
   return true;
 }
@@ -2818,9 +2814,6 @@ operator >> (SaveReaderText &reader, Game &game) {
   game_reader->value("max_next_index") >> game.max_next_index;
   game_reader->value("map.gold_morale_factor") >> game.map_gold_morale_factor;
   game_reader->value("player_score_leader") >> game.player_score_leader;
-
-  /* Allocate game objects */
-  game.allocate_objects();
 
   sections = reader.get_sections("player");
   for (Readers::iterator it = sections.begin(); it != sections.end(); ++it) {

--- a/src/savegame.cc
+++ b/src/savegame.cc
@@ -234,6 +234,18 @@ class SaveReaderTextFile : public SaveReaderText {
 };
 
 bool
+load_text_state(std::istream *is, Game *game) {
+  try {
+    SaveReaderTextFile reader_text(is);
+    reader_text >> *game;
+  } catch (...) {
+    return false;
+  }
+
+  return true;
+}
+
+bool
 load_state(const std::string &path, Game *game) {
   std::ifstream file;
   file.open(path.c_str());

--- a/src/savegame.h
+++ b/src/savegame.h
@@ -22,6 +22,7 @@
 #ifndef SRC_SAVEGAME_H_
 #define SRC_SAVEGAME_H_
 
+#include <iostream>
 #include <string>
 #include <list>
 
@@ -40,11 +41,11 @@
 #include "src/debug.h"
 
 /* Original game format */
-bool load_v0_state(FILE *f);
+bool load_v0_state(std::istream *is);
 
 /* Text format */
-bool save_text_state(FILE *f, Game *game);
-bool load_text_state(FILE *f, Game *game);
+bool save_text_state(std::ostream *os, Game *game);
+bool load_text_state(std::istream *is, Game *game);
 
 /* Generic save/load function that will try to detect the right
    format on load and save to the best format on write. */

--- a/tests/test_save_game.cc
+++ b/tests/test_save_game.cc
@@ -1,0 +1,71 @@
+/*
+ * test_map.cc - TAP test for loading/saving game
+ *
+ * Copyright (C) 2016  Jon Lund Steffensen <jonlst@gmail.com>
+ *
+ * This file is part of freeserf.
+ *
+ * freeserf is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * freeserf is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with freeserf.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <sstream>
+
+#include "src/game.h"
+#include "src/random.h"
+#include "src/savegame.h"
+
+int
+main(int argc, char *argv[]) {
+  // Print number of tests for TAP
+  std::cout << "1..3" << "\n";
+
+  // Create random map game
+  Game *game = new Game(0);
+  game->init();
+  game->load_random_map(3, Random("8667715887436237"));
+
+  // Run game for a number of ticks
+  for (int i = 0; i < 100; i++) game->update();
+
+  std::cout << "ok 1 - Random map game started and running\n";
+
+  // Save the game state
+  std::stringstream str;
+  bool saved = save_text_state(&str, game);
+  str.flush();
+
+  if (saved && str.good()) {
+    std::cout << "ok 2 - Saved game state\n";
+  } else {
+    std::cout << "not ok 2 - Failed to save game state; returned " <<
+      saved << "\n";
+    return 0;
+  }
+
+  // Load the game state into a new game
+  str.seekg(0, std::ios::beg);
+  Game *loaded_game = new Game(0);
+  bool loaded = load_text_state(&str, loaded_game);
+
+  if (loaded) {
+    std::cout << "ok 3 - Loaded game state\n";
+  } else {
+    std::cout << "not ok 3 - Failed to load save game state; returned " <<
+      loaded << "\n";
+    return 0;
+  }
+
+  delete game;
+}


### PR DESCRIPTION
First two commits change the load/save state functions in `savegame.cc` to use the iostream API instead of using `FILE`. This makes it easier to implement a test program using `stringstream` from the iostream API.

Next commit fixes a bug that initially made this test fail. This is a regression from a while back that only affected save games where no buildings were present.

Lastly, the test program is added which starts a game, saves the game state, then tries to load it back. It doesn't yet check whether the loaded state is correct. I would expand this test in the future since it seems that there are still a number of bugs when loading a game file.