### PR TITLE
Test loaded map

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -2815,6 +2815,21 @@ operator >> (SaveReaderText &reader, Game &game) {
   game_reader->value("map.gold_morale_factor") >> game.map_gold_morale_factor;
   game_reader->value("player_score_leader") >> game.player_score_leader;
 
+  int gold_deposit;
+  game_reader->value("gold_deposit") >> gold_deposit;
+  game.map->add_gold_deposit(gold_deposit);
+
+  Map::UpdateState update_state;
+  int x, y;
+  game_reader->value("update_state.remove_signs_counter") >>
+    update_state.remove_signs_counter;
+  game_reader->value("update_state.last_tick") >> update_state.last_tick;
+  game_reader->value("update_state.counter") >> update_state.counter;
+  game_reader->value("update_state.initial_pos")[0] >> x;
+  game_reader->value("update_state.initial_pos")[1] >> y;
+  update_state.initial_pos = game.map->pos(x, y);
+  game.map->set_update_state(update_state);
+
   sections = reader.get_sections("player");
   for (Readers::iterator it = sections.begin(); it != sections.end(); ++it) {
     Player *p = game.players.get_or_insert((*it)->get_number());
@@ -2914,6 +2929,18 @@ operator << (SaveWriterText &writer, Game &game) {
   writer.value("max_next_index") << game.max_next_index;
   writer.value("map.gold_morale_factor") << game.map_gold_morale_factor;
   writer.value("player_score_leader") << game.player_score_leader;
+
+  writer.value("gold_deposit") << game.map->get_gold_deposit();
+
+  const Map::UpdateState& update_state = game.map->get_update_state();
+  writer.value("update_state.remove_signs_counter") <<
+    update_state.remove_signs_counter;
+  writer.value("update_state.last_tick") << update_state.last_tick;
+  writer.value("update_state.counter") << update_state.counter;
+  writer.value("update_state.initial_pos") << game.map->pos_col(
+    update_state.initial_pos);
+  writer.value("update_state.initial_pos") << game.map->pos_row(
+    update_state.initial_pos);
 
   for (Game::Players::Iterator p = game.players.begin();
        p != game.players.end(); ++p) {

--- a/src/map.cc
+++ b/src/map.cc
@@ -343,6 +343,8 @@ Map::init(unsigned int size) {
     spiral_pos_pattern = NULL;
   }
 
+  gold_deposit = 0;
+
   update_state.last_tick = 0;
   update_state.counter = 0;
   update_state.remove_signs_counter = 0;

--- a/src/map.cc
+++ b/src/map.cc
@@ -343,10 +343,10 @@ Map::init(unsigned int size) {
     spiral_pos_pattern = NULL;
   }
 
-  update_map_last_tick = 0;
-  update_map_counter = 0;
-  update_map_16_loop = 0;
-  update_map_initial_pos = 0;
+  update_state.last_tick = 0;
+  update_state.counter = 0;
+  update_state.remove_signs_counter = 0;
+  update_state.initial_pos = 0;
 
   this->size = size;
 
@@ -569,7 +569,7 @@ Map::update_public(MapPos pos, Random *rnd) {
   case ObjectSignLargeCoal: case ObjectSignSmallCoal:
   case ObjectSignLargeStone: case ObjectSignSmallStone:
   case ObjectSignEmpty:
-    if (update_map_16_loop == 0) {
+    if (update_state.remove_signs_counter == 0) {
       set_object(pos, ObjectNone, -1);
     }
     break;
@@ -614,21 +614,23 @@ Map::update_hidden(MapPos pos, Random *rnd) {
 /* Update map data as part of the game progression. */
 void
 Map::update(unsigned int tick, Random *rnd) {
-  uint16_t delta = tick - update_map_last_tick;
-  update_map_last_tick = tick;
-  update_map_counter -= delta;
+  uint16_t delta = tick - update_state.last_tick;
+  update_state.last_tick = tick;
+  update_state.counter -= delta;
 
   int iters = 0;
-  while (update_map_counter < 0) {
+  while (update_state.counter < 0) {
     iters += regions;
-    update_map_counter += 20;
+    update_state.counter += 20;
   }
 
-  MapPos pos = update_map_initial_pos;
+  MapPos pos = update_state.initial_pos;
 
   for (int i = 0; i < iters; i++) {
-    update_map_16_loop -= 1;
-    if (update_map_16_loop < 0) update_map_16_loop = 16;
+    update_state.remove_signs_counter -= 1;
+    if (update_state.remove_signs_counter < 0) {
+      update_state.remove_signs_counter = 16;
+    }
 
     /* Test if moving 23 positions right crosses map boundary. */
     if (pos_col(pos) + 23 < static_cast<int>(cols)) {
@@ -643,7 +645,7 @@ Map::update(unsigned int tick, Random *rnd) {
     update_public(pos, rnd);
   }
 
-  update_map_initial_pos = pos;
+  update_state.initial_pos = pos;
 }
 
 /* Return non-zero if the road segment from pos in direction dir

--- a/src/map.cc
+++ b/src/map.cc
@@ -852,6 +852,41 @@ Map::types_within(MapPos pos, Terrain low, Terrain high) {
   return false;
 }
 
+bool
+Map::operator == (const Map& rhs) const {
+  // Check fundamental properties
+  if (this->size != rhs.size ||
+      this->col_size != rhs.col_size ||
+      this->row_size != rhs.row_size ||
+      this->regions != rhs.regions ||
+      this->gold_deposit != rhs.gold_deposit ||
+      this->update_state != rhs.update_state) {
+    return false;
+  }
+
+  // Check all tiles
+  for (unsigned int y = 0; y < rows; y++) {
+    for (unsigned int x = 0; x < cols; x++) {
+      MapPos pos_ = pos(x, y);
+      if (pos_ != rhs.pos(x, y)) return false;
+
+      if (this->landscape_tiles[pos_] != rhs.landscape_tiles[pos_]) {
+        return false;
+      }
+      if (this->game_tiles[pos_] != rhs.game_tiles[pos_]) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool
+Map::operator != (const Map& rhs) const {
+  return !(*this == rhs);
+}
+
 SaveReaderBinary&
 operator >> (SaveReaderBinary &reader, Map &map) {
   uint8_t v8;

--- a/src/map.cc
+++ b/src/map.cc
@@ -916,7 +916,7 @@ operator >> (SaveReaderText &reader, Map &map) {
 
       try {
         reader.value("owner")[y*SAVE_MAP_TILE_SIZE+x] >> val;
-        map.game_tiles[p].owner = val;
+        map.game_tiles[p].owner = val + 1;
         reader.value("height")[y*SAVE_MAP_TILE_SIZE+x] >> val;
         map.landscape_tiles[p].height = val;
       } catch (...) {

--- a/src/map.h
+++ b/src/map.h
@@ -297,6 +297,17 @@ class Map {
     int resource_amount;
     // Mingled fields
     Object obj;
+
+    bool operator == (const LandscapeTile& rhs) const {
+      return this->height == rhs.height &&
+        this->type_up == rhs.type_up &&
+        this->type_down == rhs.type_down &&
+        this->mineral == rhs.mineral &&
+        this->resource_amount == rhs.resource_amount &&
+        this->obj == rhs.obj;
+    }
+    bool operator != (const LandscapeTile& rhs) const {
+      return !(*this == rhs); }
   } LandscapeTile;
 
   struct UpdateState {
@@ -304,6 +315,16 @@ class Map {
     uint16_t last_tick;
     int counter;
     MapPos initial_pos;
+
+    bool operator == (const UpdateState& rhs) const {
+      return this->remove_signs_counter == rhs.remove_signs_counter &&
+        this->last_tick == rhs.last_tick &&
+        this->counter == rhs.counter &&
+        this->initial_pos == rhs.initial_pos;
+    }
+    bool operator != (const UpdateState& rhs) const {
+      return !(*this == rhs);
+    }
   };
 
  protected:
@@ -313,6 +334,16 @@ class Map {
     unsigned int owner;
     bool idle_serf;
     unsigned int obj_index;
+
+    bool operator == (const GameTile& rhs) const {
+      return this->paths == rhs.paths &&
+        this->serf == rhs.serf &&
+        this->owner == rhs.owner &&
+        this->idle_serf == rhs.idle_serf &&
+        this->obj_index == rhs.obj_index;
+    }
+    bool operator != (const GameTile& rhs) const {
+      return !(*this == rhs); }
   } GameTile;
 
   /* Fundamentals */
@@ -486,6 +517,9 @@ class Map {
   Direction remove_road_segment(MapPos *pos, Direction dir);
   bool road_segment_in_water(MapPos pos, Direction dir);
   bool is_road_segment_valid(MapPos pos, Direction dir);
+
+  bool operator == (const Map& rhs) const;
+  bool operator != (const Map& rhs) const;
 
   friend SaveReaderBinary&
     operator >> (SaveReaderBinary &reader, Map &map);

--- a/src/map.h
+++ b/src/map.h
@@ -299,6 +299,13 @@ class Map {
     Object obj;
   } LandscapeTile;
 
+  struct UpdateState {
+    int remove_signs_counter;
+    uint16_t last_tick;
+    int counter;
+    MapPos initial_pos;
+  };
+
  protected:
   typedef struct GameTile {
     uint8_t paths;
@@ -325,10 +332,7 @@ class Map {
 
   uint32_t gold_deposit;
 
-  int16_t update_map_16_loop;
-  uint16_t update_map_last_tick;
-  int16_t update_map_counter;
-  MapPos update_map_initial_pos;
+  UpdateState update_state;
 
   /* Callback for map height changes */
   typedef std::list<Handler*> change_handlers_t;

--- a/src/map.h
+++ b/src/map.h
@@ -469,6 +469,10 @@ class Map {
   void init_tiles(const MapGenerator &generator);
 
   void update(unsigned int tick, Random *rnd);
+  const UpdateState& get_update_state() const { return update_state; }
+  void set_update_state(const UpdateState& update_state_) {
+    update_state = update_state_;
+  }
 
   void add_change_handler(Handler *handler);
   void del_change_handler(Handler *handler);

--- a/tests/test_save_game.cc
+++ b/tests/test_save_game.cc
@@ -29,7 +29,7 @@
 int
 main(int argc, char *argv[]) {
   // Print number of tests for TAP
-  std::cout << "1..3" << "\n";
+  std::cout << "1..4" << "\n";
 
   // Create random map game
   Game *game = new Game(0);
@@ -67,5 +67,13 @@ main(int argc, char *argv[]) {
     return 0;
   }
 
+  // Check map
+  if (*game->get_map() == *loaded_game->get_map()) {
+    std::cout << "ok 4 - Maps are equal\n";
+  } else {
+    std::cout << "not ok 4 - Map equality test failed\n";
+  }
+
   delete game;
+  delete loaded_game;
 }


### PR DESCRIPTION
First two commits organize the map update state into a separate struct. Third commit is adding map update state and gold deposit to loaded and saved state for game. Fourth commit resets gold deposit when initializing Map. This is needed to load the gold deposit value correctly. Fifth commit fixes a bug where the map ownership is loaded incorrectly. Sixth commit adds an `operator ==` on Map to allow comparing two Map instances. Last commit checks the map equality of the original and the loaded game in `test_save_game`.

In the future I think the `gold_deposit` state should probably be moved to Game. It can also possibly be recalculated after loading the game instead of storing it in the save game file. The map tile ownership could also probably be removed from the save game and recalculated after loading.