### PR TITLE
game: Remove map generator constructor parameter

### DIFF
--- a/src/freeserf.cc
+++ b/src/freeserf.cc
@@ -74,11 +74,10 @@ main(int argc, char *argv[]) {
   int screen_width = DEFAULT_SCREEN_WIDTH;
   int screen_height = DEFAULT_SCREEN_HEIGHT;
   bool fullscreen = false;
-  int map_generator = 0;
 
 #ifdef HAVE_GETOPT_H
   while (true) {
-    char opt = getopt(argc, argv, "d:fg:hl:r:t:");
+    char opt = getopt(argc, argv, "d:fg:hl:r:");
     if (opt < 0) break;
 
     switch (opt) {
@@ -115,9 +114,6 @@ main(int argc, char *argv[]) {
           screen_width = atoi(optarg);
           screen_height = atoi(hstr+1);
         }
-        break;
-      case 't':
-        map_generator = atoi(optarg);
         break;
       default:
         fprintf(stderr, USAGE, argv[0]);
@@ -158,7 +154,7 @@ main(int argc, char *argv[]) {
     player->play_track(Audio::TypeMidiTrack0);
   }
 
-  Game *game = new Game(map_generator);
+  Game *game = new Game();
   game->init();
 
   /* Either load a save game if specified or

--- a/src/game-init.cc
+++ b/src/game-init.cc
@@ -225,7 +225,7 @@ GameInitBox::handle_action(int action) {
 
   switch (action) {
     case ActionStartGame: {
-      Game *game = new Game(0);
+      Game *game = new Game();
       game->init();
       if (game_mission < 0) {
         if (!game->load_random_map(map_size, mission->rnd)) return;

--- a/src/game.cc
+++ b/src/game.cc
@@ -42,9 +42,8 @@
 
 #define GROUND_ANALYSIS_RADIUS  25
 
-Game::Game(int _map_generator) {
+Game::Game() {
   map = NULL;
-  map_generator = _map_generator;
 
   players = Players(this);
   flags = Flags(this);

--- a/src/game.h
+++ b/src/game.h
@@ -95,7 +95,6 @@ class Game : public EventLoop::Handler {
   int game_type;
   int tutorial_level;
   int mission_level;
-  int map_generator;
   int map_preserve_bugs;
   int player_score_leader;
 
@@ -103,7 +102,7 @@ class Game : public EventLoop::Handler {
   int inventory_schedule_counter;
 
  public:
-  explicit Game(int map_generator);
+  Game();
   virtual ~Game();
 
   Map *get_map() { return map; }

--- a/src/savegame.cc
+++ b/src/savegame.cc
@@ -38,7 +38,7 @@ load_v0_state(std::istream *is) {
   std::vector<char> data(is_start, is_end);
 
   SaveReaderBinary reader(&data[0], 8628);
-  Game *game = new Game(0);
+  Game *game = new Game();
   reader >> *game;
 
   return true;

--- a/tests/test_save_game.cc
+++ b/tests/test_save_game.cc
@@ -32,7 +32,7 @@ main(int argc, char *argv[]) {
   std::cout << "1..4" << "\n";
 
   // Create random map game
-  Game *game = new Game(0);
+  Game *game = new Game();
   game->init();
   game->load_random_map(3, Random("8667715887436237"));
 
@@ -56,7 +56,7 @@ main(int argc, char *argv[]) {
 
   // Load the game state into a new game
   str.seekg(0, std::ios::beg);
-  Game *loaded_game = new Game(0);
+  Game *loaded_game = new Game();
   bool loaded = load_text_state(&str, loaded_game);
 
   if (loaded) {


### PR DESCRIPTION
Removes map generator parameter from command line and from `Game` constructor. The `map_generator` member in `Game` was no longer used.