### PR TITLE
Move total gold counter to Game

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -1482,10 +1482,10 @@ Game::build_castle(MapPos pos, Player *player) {
   inventory->set_owner(player->get_index());
   inventory->apply_supplies_preset(player->get_initial_supplies());
 
-  map->add_gold_deposit(static_cast<int>(
-                               inventory->get_count_of(Resource::TypeGoldBar)));
-  map->add_gold_deposit(static_cast<int>(
-                               inventory->get_count_of(Resource::TypeGoldOre)));
+  add_gold_total(static_cast<int>(
+    inventory->get_count_of(Resource::TypeGoldBar)));
+  add_gold_total(static_cast<int>(
+    inventory->get_count_of(Resource::TypeGoldOre)));
 
   castle->set_position(pos);
   flag->set_position(map->move_down_right(pos));
@@ -1635,7 +1635,7 @@ Game::demolish_building_(MapPos pos) {
        building->get_type() == Building::TypeFortress ||
        building->get_type() == Building::TypeGoldSmelter)) {
     int gold_stock = building->get_res_count_in_stock(1);
-    map->add_gold_deposit(-gold_stock);
+    add_gold_total(-gold_stock);
   }
 
   /* Update land owner ship if the building is military. */
@@ -1655,10 +1655,10 @@ Game::demolish_building_(MapPos pos) {
 
       inventory->lose_queue();
 
-      map->add_gold_deposit(-static_cast< int >(
-                           inventory->get_count_of(Resource::TypeGoldBar)));
-      map->add_gold_deposit(-static_cast< int >(
-                           inventory->get_count_of(Resource::TypeGoldOre)));
+      add_gold_total(-static_cast<int>(
+        inventory->get_count_of(Resource::TypeGoldBar)));
+      add_gold_total(-static_cast<int>(
+        inventory->get_count_of(Resource::TypeGoldOre)));
 
       inventories.erase(inventory->get_index());
     }
@@ -2163,6 +2163,7 @@ Game::init_map(int size) {
 void
 Game::init_map_data(const MapGenerator& generator) {
   this->map->init_tiles(generator);
+  gold_total = map->get_gold_deposit();
 }
 
 void
@@ -2297,7 +2298,7 @@ Game::cancel_transported_resource(Resource::Type res, unsigned int dest) {
 void
 Game::lose_resource(Resource::Type res) {
   if (res == Resource::TypeGoldOre || res == Resource::TypeGoldBar) {
-    map->add_gold_deposit(-1);
+    add_gold_total(-1);
   }
 }
 
@@ -2814,9 +2815,7 @@ operator >> (SaveReaderText &reader, Game &game) {
   game_reader->value("map.gold_morale_factor") >> game.map_gold_morale_factor;
   game_reader->value("player_score_leader") >> game.player_score_leader;
 
-  int gold_deposit;
-  game_reader->value("gold_deposit") >> gold_deposit;
-  game.map->add_gold_deposit(gold_deposit);
+  game_reader->value("gold_deposit") >> game.gold_total;
 
   Map::UpdateState update_state;
   int x, y;
@@ -2929,7 +2928,7 @@ operator << (SaveWriterText &writer, Game &game) {
   writer.value("map.gold_morale_factor") << game.map_gold_morale_factor;
   writer.value("player_score_leader") << game.player_score_leader;
 
-  writer.value("gold_deposit") << game.map->get_gold_deposit();
+  writer.value("gold_deposit") << game.gold_total;
 
   const Map::UpdateState& update_state = game.map->get_update_state();
   writer.value("update_state.remove_signs_counter") <<

--- a/src/game.h
+++ b/src/game.h
@@ -22,6 +22,7 @@
 #ifndef SRC_GAME_H_
 #define SRC_GAME_H_
 
+#include <cassert>
 #include <vector>
 #include <map>
 #include <string>
@@ -61,6 +62,7 @@ class Game : public EventLoop::Handler {
 
   typedef std::map<unsigned int, unsigned int> values_t;
   int map_gold_morale_factor;
+  unsigned int gold_total;
 
   Players players;
   Flags flags;
@@ -110,6 +112,11 @@ class Game : public EventLoop::Handler {
   unsigned int get_tick() const { return tick; }
   unsigned int get_const_tick() const { return const_tick; }
   unsigned int get_gold_morale_factor() const { return map_gold_morale_factor; }
+  unsigned int get_gold_total() const { return gold_total; }
+  void add_gold_total(int delta) {
+    if (delta < 0) assert(gold_total >= -delta);
+    gold_total += delta;
+  }
 
   Building *get_building_at_pos(MapPos pos);
   Flag *get_flag_at_pos(MapPos pos);

--- a/src/map.cc
+++ b/src/map.cc
@@ -343,8 +343,6 @@ Map::init(unsigned int size) {
     spiral_pos_pattern = NULL;
   }
 
-  gold_deposit = 0;
-
   update_state.last_tick = 0;
   update_state.counter = 0;
   update_state.remove_signs_counter = 0;
@@ -387,21 +385,21 @@ Map::get_rnd_coord(int *col, int *row, Random *rnd) const {
   return pos(c, r);
 }
 
-/* Initialize global count of gold deposits. */
-void
-Map::init_ground_gold_deposit() {
-  int total_gold = 0;
+// Get count of gold mineral deposits in the map.
+unsigned int
+Map::get_gold_deposit() const {
+  int count = 0;
 
   for (unsigned int y = 0; y < rows; y++) {
     for (unsigned int x = 0; x < cols; x++) {
       MapPos pos_ = pos(x, y);
       if (get_res_type(pos_) == MineralsGold) {
-        total_gold += get_res_amount(pos_);
+        count += get_res_amount(pos_);
       }
     }
   }
 
-  gold_deposit = total_gold;
+  return count;
 }
 
 /* Initialize spiral_pos_pattern from spiral_pattern. */
@@ -461,8 +459,6 @@ void
 Map::init_tiles(const MapGenerator &generator) {
   memcpy(landscape_tiles, generator.get_landscape(),
          rows * cols * sizeof(LandscapeTile));
-
-  init_ground_gold_deposit();
 }
 
 /* Change the height of a map position. */
@@ -859,7 +855,6 @@ Map::operator == (const Map& rhs) const {
       this->col_size != rhs.col_size ||
       this->row_size != rhs.row_size ||
       this->regions != rhs.regions ||
-      this->gold_deposit != rhs.gold_deposit ||
       this->update_state != rhs.update_state) {
     return false;
   }

--- a/src/map.h
+++ b/src/map.h
@@ -361,8 +361,6 @@ class Map {
 
   uint16_t regions;
 
-  uint32_t gold_deposit;
-
   UpdateState update_state;
 
   /* Callback for map height changes */
@@ -491,8 +489,7 @@ class Map {
   void remove_fish(MapPos pos, int amount);
   void set_serf_index(MapPos pos, int index);
 
-  unsigned int get_gold_deposit() const { return gold_deposit; }
-  void add_gold_deposit(int delta) { gold_deposit += delta; }
+  unsigned int get_gold_deposit() const;
 
   void init(unsigned int size);
   void init_dimensions();
@@ -531,7 +528,6 @@ class Map {
  protected:
   void deinit();
 
-  void init_ground_gold_deposit();
   void init_spiral_pos_pattern();
 
   void update_public(MapPos pos, Random *rnd);

--- a/src/player.cc
+++ b/src/player.cc
@@ -896,14 +896,14 @@ Player::update_knight_morale() {
   gold_deposited = inventory_gold + military_gold;
 
   /* Calculate according to gold collected. */
-  unsigned int map_gold = game->get_map()->get_gold_deposit();
-  if (map_gold != 0) {
-    while (map_gold > 0xffff) {
-      map_gold >>= 1;
+  unsigned int total_gold = game->get_gold_total();
+  if (total_gold != 0) {
+    while (total_gold > 0xffff) {
+      total_gold >>= 1;
       depot >>= 1;
     }
-    depot = std::min(depot, map_gold-1);
-    knight_morale = 1024 + (game->get_gold_morale_factor() * depot)/map_gold;
+    depot = std::min(depot, total_gold-1);
+    knight_morale = 1024 + (game->get_gold_morale_factor() * depot)/total_gold;
   } else {
     knight_morale = 4096;
   }

--- a/tests/test_save_game.cc
+++ b/tests/test_save_game.cc
@@ -29,7 +29,7 @@
 int
 main(int argc, char *argv[]) {
   // Print number of tests for TAP
-  std::cout << "1..4" << "\n";
+  std::cout << "1..5" << "\n";
 
   // Create random map game
   Game *game = new Game();
@@ -72,6 +72,13 @@ main(int argc, char *argv[]) {
     std::cout << "ok 4 - Maps are equal\n";
   } else {
     std::cout << "not ok 4 - Map equality test failed\n";
+  }
+
+  // Check gold deposit
+  if (game->get_gold_total() == loaded_game->get_gold_total()) {
+    std::cout << "ok 5 - Total gold count is identical\n";
+  } else {
+    std::cout << "not ok 5 - Total gold count is not identical\n";
   }
 
   delete game;


### PR DESCRIPTION
Previously the `Map` was keeping track of the total amount of gold in the game (including unmined gold ore, gold at flags/inventories/other buildings, transported gold/ore, etc.) This counter was moved to Game and a method on `Map` was added to return the current amount of gold in mineral deposits. The name of the method on `Game` was changed from `get_gold_deposit()` to `get_gold_total()` since the method is really counting the total gold present in the game, not just the gold deposited as minerals in the map.