### PR TITLE
Fail properly when trying to load binary save games instead of segfaulting

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -2601,8 +2601,15 @@ operator >> (SaveReaderBinary &reader, Game &game) {
 
   reader.skip(8);
   reader >> v16;  // 190
+  int map_size = v16;
+
+  // Avoid allocating a huge map if the input file is invalid
+  if (map_size < 3 || map_size > 10) {
+    throw ExceptionFreeserf("Invalid map size in file");
+  }
+
   game.map = new Map();
-  game.map->init(v16);
+  game.map->init(map_size);
 
   reader.skip(8);
   reader >> v16;  // 200

--- a/src/savegame.cc
+++ b/src/savegame.cc
@@ -33,13 +33,16 @@
 
 /* Load a save game. */
 bool
-load_v0_state(std::istream *is) {
+load_v0_state(std::istream *is, Game *game) {
   std::istreambuf_iterator<char> is_start(*is), is_end;
   std::vector<char> data(is_start, is_end);
 
-  SaveReaderBinary reader(&data[0], 8628);
-  Game *game = new Game();
-  reader >> *game;
+  SaveReaderBinary reader(&data[0], data.size());
+  try {
+    reader >> *game;
+  } catch (...) {
+    return false;
+  }
 
   return true;
 }

--- a/src/savegame.cc
+++ b/src/savegame.cc
@@ -302,6 +302,7 @@ SaveReaderBinary::SaveReaderBinary(void *data, size_t size) {
 
 SaveReaderBinary&
 SaveReaderBinary::operator >> (uint8_t &val) {
+  if (!has_data_left(1)) throw ExceptionFreeserf("Invalid read past end.");
   val = *current;
   current++;
   return *this;
@@ -309,6 +310,7 @@ SaveReaderBinary::operator >> (uint8_t &val) {
 
 SaveReaderBinary&
 SaveReaderBinary::operator >> (uint16_t &val) {
+  if (!has_data_left(2)) throw ExceptionFreeserf("Invalid read past end.");
   val = *reinterpret_cast<uint16_t*>(current);
   current += 2;
   return *this;
@@ -316,6 +318,7 @@ SaveReaderBinary::operator >> (uint16_t &val) {
 
 SaveReaderBinary&
 SaveReaderBinary::operator >> (uint32_t &val) {
+  if (!has_data_left(4)) throw ExceptionFreeserf("Invalid read past end.");
   val = *reinterpret_cast<uint32_t*>(current);
   current += 4;
   return *this;
@@ -331,6 +334,10 @@ SaveReaderBinary::operator = (const SaveReaderBinary& other) {
 
 SaveReaderBinary
 SaveReaderBinary::extract(size_t size) {
+  if (!has_data_left(size)) {
+    throw ExceptionFreeserf("Invalid extract past end.");
+  }
+
   SaveReaderBinary new_reader(current, size);
   current += size;
   return new_reader;
@@ -338,9 +345,7 @@ SaveReaderBinary::extract(size_t size) {
 
 uint8_t *
 SaveReaderBinary::read(size_t size) {
-  if (current + size > end) {
-    return NULL;
-  }
+  if (!has_data_left(size)) throw ExceptionFreeserf("Invalid read past end.");
   uint8_t *data = current;
   current += size;
   return data;

--- a/src/savegame.cc
+++ b/src/savegame.cc
@@ -261,19 +261,18 @@ load_state(const std::string &path, Game *game) {
   try {
     SaveReaderTextFile reader_text(&file);
     reader_text >> *game;
+  } catch (ExceptionFreeserf& e) {
     file.close();
-  } catch (...) {
-    file.close();
-    Log::Warn["savegame"] << "Unable to load save game, "
-                          << "trying compatability mode...";
+    Log::Warn["savegame"] << "Unable to load save game: " << e.what();
+    Log::Warn["savegame"] << "Trying compatability mode...";
     std::ifstream input(path.c_str(), std::ios::binary);
     std::vector<char> buffer((std::istreambuf_iterator<char>(input)),
                              (std::istreambuf_iterator<char>()));
     SaveReaderBinary reader(&buffer[0], buffer.size());
     try {
       reader >> *game;
-    } catch (...) {
-      Log::Error["savegame"] << "Failed to load save game.";
+    } catch (ExceptionFreeserf& e) {
+      Log::Error["savegame"] << "Failed to load save game: " << e.what();
       return false;
     }
   }

--- a/src/savegame.h
+++ b/src/savegame.h
@@ -73,6 +73,7 @@ class SaveReaderBinary {
   void skip(size_t count) { current += count; }
   SaveReaderBinary extract(size_t size);
   uint8_t *read(size_t size);
+  bool has_data_left(size_t size) const { return current + size <= end; }
 };
 
 class SaveReaderTextValue {

--- a/src/savegame.h
+++ b/src/savegame.h
@@ -41,7 +41,7 @@
 #include "src/debug.h"
 
 /* Original game format */
-bool load_v0_state(std::istream *is);
+bool load_v0_state(std::istream *is, Game *game);
 
 /* Text format */
 bool save_text_state(std::ostream *os, Game *game);


### PR DESCRIPTION
`SaveReaderBinary` is changed so that `has_data_left()` is checked before every read to guard against reads outside of the underlying memory area. An exception is thrown when this happens.  Second commit fixed `load_v0_state()` which would always return true and not allow the loaded `Game` state to be accessed. Third commit logs load game failures to make debugging easier. Last commit adds an additional check for map size so that the load fails when the map size is too small or too large.