### PR TITLE
game: Remove redundant method with misspelled name

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -2465,11 +2465,6 @@ Game::get_serfs_related_to(unsigned int dest, Direction dir) {
   return result;
 }
 
-Flag *
-Game::gat_flag_at_pos(MapPos pos) {
-  return flags[map->get_obj_index(pos)];
-}
-
 Player *
 Game::get_next_player(Player *player) {
   Players::Iterator p = players.begin();

--- a/src/game.h
+++ b/src/game.h
@@ -212,7 +212,6 @@ class Game : public EventLoop::Handler {
   ListInventories get_player_inventories(Player *player);
 
   ListSerfs get_serfs_at_pos(MapPos pos);
-  Flag *gat_flag_at_pos(MapPos pos);
 
   Player *get_next_player(Player *player);
   unsigned int get_enemy_score(Player *player);

--- a/src/popup.cc
+++ b/src/popup.cc
@@ -2781,7 +2781,7 @@ PopupBox::move_sett_5_6_item(int up, int to_end) {
 void
 PopupBox::handle_send_geologist() {
   MapPos pos = interface->get_map_cursor_pos();
-  Flag *flag = interface->get_game()->gat_flag_at_pos(pos);
+  Flag *flag = interface->get_game()->get_flag_at_pos(pos);
 
   if (!interface->get_game()->send_geologist(flag)) {
     play_sound(Audio::TypeSfxNotAccepted);


### PR DESCRIPTION
Removes `gat_flag_at_pos()` which is a redundant copy of the method `get_flag_at_pos()`.