### PR TITLE
Map geometry

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ GAME_SOURCES = \
 	src/log.cc src/log.h \
 	src/map.cc src/map.h \
 	src/map-generator.cc src/map-generator.h \
+	src/map-geometry.h \
 	src/mission.cc src/mission.h \
 	src/objects.h \
 	src/player.cc src/player.h \

--- a/src/game-init.cc
+++ b/src/game-init.cc
@@ -34,6 +34,7 @@
 #include "src/text-input.h"
 #include "src/minimap.h"
 #include "src/map-generator.h"
+#include "src/map-geometry.h"
 
 class RandomInput : public TextInput {
  protected:
@@ -434,9 +435,8 @@ GameInitBox::generate_map_preview() {
     map = NULL;
   }
 
-  map = new Map();
   if (game_mission < 0) {
-    map->init(map_size);
+    map = new Map(MapGeometry(map_size));
     {
       ClassicMapGenerator generator(*map, mission->rnd);
       generator.init(MapGenerator::HeightGeneratorMidpoints, true);
@@ -444,7 +444,7 @@ GameInitBox::generate_map_preview() {
       map->init_tiles(generator);
     }
   } else {
-    map->init(3);
+    map = new Map(MapGeometry(3));
     {
       ClassicMissionMapGenerator generator(*map, mission->rnd);
       generator.init();

--- a/src/game.cc
+++ b/src/game.cc
@@ -39,6 +39,7 @@
 #include "src/misc.h"
 #include "src/inventory.h"
 #include "src/map-generator.h"
+#include "src/map-geometry.h"
 
 #define GROUND_ANALYSIS_RADIUS  25
 
@@ -2156,8 +2157,7 @@ Game::init_map(int size) {
     map = NULL;
   }
 
-  map = new Map();
-  map->init(size);
+  map = new Map(MapGeometry(size));
 }
 
 void
@@ -2225,7 +2225,7 @@ Game::load_mission_map(int level) {
 
   init_map(3);
   {
-    ClassicMissionMapGenerator generator(*this->map, init_map_rnd);
+    ClassicMissionMapGenerator generator(*map, init_map_rnd);
     generator.init();
     generator.generate();
     init_map_data(generator);
@@ -2259,7 +2259,7 @@ Game::load_random_map(int size, const Random &rnd) {
 
   init_map(size);
   {
-    ClassicMapGenerator generator(*this->map, rnd);
+    ClassicMapGenerator generator(*map, rnd);
     generator.init(MapGenerator::HeightGeneratorMidpoints, false);
     generator.generate();
     init_map_data(generator);
@@ -2603,8 +2603,7 @@ operator >> (SaveReaderBinary &reader, Game &game) {
     throw ExceptionFreeserf("Invalid map size in file");
   }
 
-  game.map = new Map();
-  game.map->init(map_size);
+  game.map = new Map(MapGeometry(map_size));
 
   reader.skip(8);
   reader >> v16;  // 200
@@ -2773,9 +2772,7 @@ operator >> (SaveReaderText &reader, Game &game) {
   }
 
   /* Initialize remaining map dimensions. */
-  game.map = new Map();
-  game.map->init(size);
-  game.map->init_dimensions();
+  game.map = new Map(MapGeometry(size));
   sections = reader.get_sections("map");
   for (Readers::iterator it = sections.begin(); it != sections.end(); ++it) {
     **it >> *game.map;

--- a/src/game.cc
+++ b/src/game.cc
@@ -2681,13 +2681,10 @@ Game::load_flags(SaveReaderBinary *reader, int max_flag_index) {
   }
 
   /* Set flag positions. */
-  for (unsigned int y = 0; y < map->get_rows(); y++) {
-    for (unsigned int x = 0; x < map->get_cols(); x++) {
-      MapPos pos = map->pos(x, y);
-      if (map->get_obj(pos) == Map::ObjectFlag) {
-        Flag *flag = flags[map->get_obj_index(pos)];
-        flag->set_position(pos);
-      }
+  for (MapPos pos : map->geom()) {
+    if (map->get_obj(pos) == Map::ObjectFlag) {
+      Flag *flag = flags[map->get_obj_index(pos)];
+      flag->set_position(pos);
     }
   }
 

--- a/src/map-geometry.h
+++ b/src/map-geometry.h
@@ -99,6 +99,39 @@ class MapGeometry {
   unsigned int row_shift_;
 
  public:
+  class Iterator {
+   protected:
+    const MapGeometry& geom;
+    MapPos pos;
+
+   public:
+    explicit Iterator(const MapGeometry& geom, MapPos pos)
+    : geom(geom), pos(pos) {}
+    Iterator(const Iterator& that)
+    : geom(that.geom), pos(that.pos) {}
+
+    Iterator& operator ++() {
+      if (pos < geom.tile_count()) {
+        pos++;
+      }
+      return *this;
+    }
+
+    Iterator operator ++(int) {
+      Iterator tmp(*this);
+      operator++();
+      return tmp;
+    }
+
+    bool operator == (const Iterator& rhs) const {
+      return this->geom == rhs.geom && this->pos == rhs.pos; }
+    bool operator != (const Iterator& rhs) const { return !(*this == rhs); }
+
+    MapPos operator * () const {
+      return pos;
+    }
+  };
+
   explicit MapGeometry(unsigned int size)
   : size_(size) {
     // Above size 20 the map positions can no longer fit in a 32-bit integer.
@@ -167,6 +200,9 @@ class MapGeometry {
     return pos_add(pos, dirs[DirectionRight]*n); }
   MapPos move_down_n(MapPos pos, int n) const {
     return pos_add(pos, dirs[DirectionDown]*n); }
+
+  Iterator begin() const { return Iterator(*this, 0); }
+  Iterator end() const { return Iterator(*this, tile_count()); }
 
   bool operator == (const MapGeometry& rhs) const {
     return this->size_ == rhs.size_; }

--- a/src/map-geometry.h
+++ b/src/map-geometry.h
@@ -1,0 +1,176 @@
+//
+// map-geometry.h - Map geometry functions
+//
+// Copyright (C) 2013-2016  Jon Lund Steffensen <jonlst@gmail.com>
+//
+// This file is part of freeserf.
+//
+// freeserf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// freeserf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with freeserf.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef SRC_MAP_GEOMETRY_H_
+#define SRC_MAP_GEOMETRY_H_
+
+#include <cassert>
+
+#include <limits>
+#include <utility>
+
+// Map directions
+//
+//    A ______ B
+//     /\    /
+//    /  \  /
+// C /____\/ D
+//
+// Six standard directions:
+// RIGHT: A to B
+// DOWN_RIGHT: A to D
+// DOWN: A to C
+// LEFT: D to C
+// UP_LEFT: D to A
+// UP: D to B
+//
+// Non-standard directions:
+// UP_RIGHT: C to B
+// DOWN_LEFT: B to C
+typedef enum Direction {
+  DirectionNone = -1,
+
+  DirectionRight = 0,
+  DirectionDownRight,
+  DirectionDown,
+  DirectionLeft,
+  DirectionUpLeft,
+  DirectionUp,
+
+  DirectionUpRight,
+  DirectionDownLeft
+} Direction;
+
+// Return the given direction turned clockwise a number of times.
+//
+// Return the resulting direction from turning the given direction
+// clockwise in 60 degree increment the specified number of times.
+// If times is a negative number the direction will be turned counter
+// clockwise.
+//
+// NOTE: Only valid for the six standard directions.
+inline Direction turn_direction(Direction d, int times) {
+  int td = (static_cast<int>(d) + times) % 6;
+  if (td < 0) td += 6;
+  return static_cast<Direction>(td);
+}
+
+// Return the given direction reversed.
+//
+// NOTE: Only valid for the six standard directions.
+inline Direction reverse_direction(Direction d) {
+  return turn_direction(d, 3);
+}
+
+// MapPos is a compact composition of col and row values that
+// uniquely identifies a vertex in the map space. It is also used
+// directly as index to map data arrays.
+typedef unsigned int MapPos;
+const MapPos bad_map_pos = std::numeric_limits<unsigned int>::max();
+
+
+class MapGeometry {
+ protected:
+  unsigned int size_;
+
+  // Derived members
+  MapPos dirs[8];
+  unsigned int col_size_, row_size_;
+
+  unsigned int cols_, rows_;
+  unsigned int col_mask_, row_mask_;
+  unsigned int row_shift_;
+
+ public:
+  explicit MapGeometry(unsigned int size)
+  : size_(size) {
+    // Above size 20 the map positions can no longer fit in a 32-bit integer.
+    assert(size_ <= 20);
+
+    col_size_ = 5 + size_/2;
+    row_size_ = 5 + (size_ - 1)/2;
+    cols_ = 1 << col_size_;
+    rows_ = 1 << row_size_;
+
+    col_mask_ = cols_ - 1;
+    row_mask_ = rows_ - 1;
+    row_shift_ = col_size_;
+
+    // Setup direction offsets
+    dirs[DirectionRight] = 1 & col_mask_;
+    dirs[DirectionLeft] = -1 & col_mask_;
+    dirs[DirectionDown] = (1 & row_mask_) << row_shift_;
+    dirs[DirectionUp] = (-1 & row_mask_) << row_shift_;
+
+    dirs[DirectionDownRight] = dirs[DirectionRight] | dirs[DirectionDown];
+    dirs[DirectionUpRight] = dirs[DirectionRight] | dirs[DirectionUp];
+    dirs[DirectionDownLeft] = dirs[DirectionLeft] | dirs[DirectionDown];
+    dirs[DirectionUpLeft] = dirs[DirectionLeft] | dirs[DirectionUp];
+  }
+  MapGeometry(const MapGeometry& that) : MapGeometry(that.size_) {}
+
+  unsigned int size() const { return size_; }
+  unsigned int cols() const { return cols_; }
+  unsigned int rows() const { return rows_; }
+  unsigned int col_mask() const { return col_mask_; }
+  unsigned int row_mask() const { return row_mask_; }
+  unsigned int row_shift() const { return row_shift_; }
+  unsigned int tile_count() const { return cols_ * rows_; }
+
+  /* Extract col and row from MapPos */
+  int pos_col(int pos) const { return (pos & col_mask_); }
+  int pos_row(int pos) const { return ((pos >> row_shift_) & row_mask_); }
+
+  /* Translate col, row coordinate to MapPos value. */
+  MapPos pos(int x, int y) const { return ((y << row_shift_) | x); }
+
+  /* Addition of two map positions. */
+  MapPos pos_add(MapPos pos_, MapPos off) const {
+    return pos((pos_col(pos_) + pos_col(off)) & col_mask_,
+               (pos_row(pos_) + pos_row(off)) & row_mask_); }
+
+  /* Movement of map position according to directions. */
+  MapPos move(MapPos pos, Direction dir) const {
+    return pos_add(pos, dirs[dir]); }
+
+  MapPos move_right(MapPos pos) const { return move(pos, DirectionRight); }
+  MapPos move_down_right(MapPos pos) const {
+    return move(pos, DirectionDownRight); }
+  MapPos move_down(MapPos pos) const { return move(pos, DirectionDown); }
+  MapPos move_left(MapPos pos) const { return move(pos, DirectionLeft); }
+  MapPos move_up_left(MapPos pos) const { return move(pos, DirectionUpLeft); }
+  MapPos move_up(MapPos pos) const { return move(pos, DirectionUp); }
+
+  MapPos move_up_right(MapPos pos) const {
+    return move(pos, DirectionUpRight); }
+  MapPos move_down_left(MapPos pos) const {
+    return move(pos, DirectionDownLeft); }
+
+  MapPos move_right_n(MapPos pos, int n) const {
+    return pos_add(pos, dirs[DirectionRight]*n); }
+  MapPos move_down_n(MapPos pos, int n) const {
+    return pos_add(pos, dirs[DirectionDown]*n); }
+
+  bool operator == (const MapGeometry& rhs) const {
+    return this->size_ == rhs.size_; }
+  bool operator != (const MapGeometry& rhs) const { return !(*this == rhs); }
+};
+
+#endif  // SRC_MAP_GEOMETRY_H_

--- a/src/map.cc
+++ b/src/map.cc
@@ -388,12 +388,9 @@ unsigned int
 Map::get_gold_deposit() const {
   int count = 0;
 
-  for (unsigned int y = 0; y < geom_.rows(); y++) {
-    for (unsigned int x = 0; x < geom_.cols(); x++) {
-      MapPos pos_ = pos(x, y);
-      if (get_res_type(pos_) == MineralsGold) {
-        count += get_res_amount(pos_);
-      }
+  for (MapPos pos_ : geom_) {
+    if (get_res_type(pos_) == MineralsGold) {
+      count += get_res_amount(pos_);
     }
   }
 
@@ -820,17 +817,12 @@ Map::operator == (const Map& rhs) const {
   }
 
   // Check all tiles
-  for (unsigned int y = 0; y < geom_.rows(); y++) {
-    for (unsigned int x = 0; x < geom_.cols(); x++) {
-      MapPos pos_ = pos(x, y);
-      if (pos_ != rhs.pos(x, y)) return false;
-
-      if (this->landscape_tiles[pos_] != rhs.landscape_tiles[pos_]) {
-        return false;
-      }
-      if (this->game_tiles[pos_] != rhs.game_tiles[pos_]) {
-        return false;
-      }
+  for (MapPos pos_ : geom_) {
+    if (this->landscape_tiles[pos_] != rhs.landscape_tiles[pos_]) {
+      return false;
+    }
+    if (this->game_tiles[pos_] != rhs.game_tiles[pos_]) {
+      return false;
     }
   }
 

--- a/src/map.cc
+++ b/src/map.cc
@@ -74,6 +74,7 @@
 #include "src/debug.h"
 #include "src/savegame.h"
 #include "src/map-generator.h"
+#include "src/map-geometry.h"
 
 /* Facilitates quick lookup of offsets following a spiral pattern in the map data.
  The columns following the second are filled out by setup_spiral_pattern(). */
@@ -320,10 +321,32 @@ Map::map_space_from_obj[] = {
   SpaceOpen,        // Object127
 };
 
-Map::Map() {
+Map::Map(const MapGeometry& geom)
+  : geom_(geom) {
+  // Some code may still assume that map has at least size 3.
+  assert(3 <= geom.size());
+
   landscape_tiles = NULL;
   game_tiles = NULL;
   spiral_pos_pattern = NULL;
+
+  update_state.last_tick = 0;
+  update_state.counter = 0;
+  update_state.remove_signs_counter = 0;
+  update_state.initial_pos = 0;
+
+  regions = (geom.cols() >> 5) * (geom.rows() >> 5);
+
+  init_spiral_pattern();
+  init_spiral_pos_pattern();
+
+  int tile_count = geom_.tile_count();
+
+  game_tiles = new GameTile[tile_count]();
+  if (game_tiles == NULL) abort();
+
+  landscape_tiles = new LandscapeTile[tile_count]();
+  if (landscape_tiles == NULL) abort();
 }
 
 Map::~Map() {
@@ -333,36 +356,6 @@ Map::~Map() {
     delete[] spiral_pos_pattern;
     spiral_pos_pattern = NULL;
   }
-}
-
-void
-Map::init(unsigned int size) {
-  // Some code may still assume that map has at least size 3. Above size 20
-  // the map positions can no longer fit in a 32-bit integer.
-  assert(3 <= size && size <= 20);
-
-  deinit();
-
-  if (spiral_pos_pattern != NULL) {
-    delete[] spiral_pos_pattern;
-    spiral_pos_pattern = NULL;
-  }
-
-  update_state.last_tick = 0;
-  update_state.counter = 0;
-  update_state.remove_signs_counter = 0;
-  update_state.initial_pos = 0;
-
-  this->size = size;
-
-  col_size = 5 + size/2;
-  row_size = 5 + (size - 1)/2;
-  cols = 1 << col_size;
-  rows = 1 << row_size;
-
-  init_dimensions();
-
-  regions = (cols >> 5) * (rows >> 5);
 }
 
 void
@@ -382,8 +375,8 @@ Map::deinit() {
    Returned as map_pos_t and also as col and row if not NULL. */
 MapPos
 Map::get_rnd_coord(int *col, int *row, Random *rnd) const {
-  int c = rnd->random() & col_mask;
-  int r = rnd->random() & row_mask;
+  int c = rnd->random() & geom_.col_mask();
+  int r = rnd->random() & geom_.row_mask();
 
   if (col != NULL) *col = c;
   if (row != NULL) *row = r;
@@ -395,8 +388,8 @@ unsigned int
 Map::get_gold_deposit() const {
   int count = 0;
 
-  for (unsigned int y = 0; y < rows; y++) {
-    for (unsigned int x = 0; x < cols; x++) {
+  for (unsigned int y = 0; y < geom_.rows(); y++) {
+    for (unsigned int x = 0; x < geom_.cols(); x++) {
       MapPos pos_ = pos(x, y);
       if (get_res_type(pos_) == MineralsGold) {
         count += get_res_amount(pos_);
@@ -416,54 +409,18 @@ Map::init_spiral_pos_pattern() {
   }
 
   for (int i = 0; i < 295; i++) {
-    int x = spiral_pattern[2*i] & col_mask;
-    int y = spiral_pattern[2*i+1] & row_mask;
+    int x = spiral_pattern[2*i] & geom_.col_mask();
+    int y = spiral_pattern[2*i+1] & geom_.row_mask();
 
     spiral_pos_pattern[i] = pos(x, y);
   }
-}
-
-/* Set all map fields except cols/rows and col/row_size
-   which must be set. */
-void
-Map::init_dimensions() {
-  /* Initialize global lookup tables */
-  init_spiral_pattern();
-
-  tile_count = cols * rows;
-
-  col_mask = (1 << col_size) - 1;
-  row_mask = (1 << row_size) - 1;
-  row_shift = col_size;
-
-  /* Setup direction offsets. */
-  dirs[DirectionRight] = 1 & col_mask;
-  dirs[DirectionLeft] = -1 & col_mask;
-  dirs[DirectionDown] = (1 & row_mask) << row_shift;
-  dirs[DirectionUp] = (-1 & row_mask) << row_shift;
-
-  dirs[DirectionDownRight] = dirs[DirectionRight] | dirs[DirectionDown];
-  dirs[DirectionUpRight] = dirs[DirectionRight] | dirs[DirectionUp];
-  dirs[DirectionDownLeft] = dirs[DirectionLeft] | dirs[DirectionDown];
-  dirs[DirectionUpLeft] = dirs[DirectionLeft] | dirs[DirectionUp];
-
-  /* Allocate map */
-  deinit();
-
-  game_tiles = new GameTile[tile_count]();
-  if (game_tiles == NULL) abort();
-
-  landscape_tiles = new LandscapeTile[tile_count]();
-  if (landscape_tiles == NULL) abort();
-
-  init_spiral_pos_pattern();
 }
 
 /* Copy tile data from map generator into map tile data. */
 void
 Map::init_tiles(const MapGenerator &generator) {
   memcpy(landscape_tiles, generator.get_landscape(),
-         rows * cols * sizeof(LandscapeTile));
+         geom_.tile_count() * sizeof(LandscapeTile));
 }
 
 /* Change the height of a map position. */
@@ -636,7 +593,7 @@ Map::update(unsigned int tick, Random *rnd) {
     }
 
     /* Test if moving 23 positions right crosses map boundary. */
-    if (pos_col(pos) + 23 < static_cast<int>(cols)) {
+    if (pos_col(pos) + 23 < static_cast<int>(geom_.cols())) {
       pos = move_right_n(pos, 23);
     } else {
       pos = move_right_n(pos, 23);
@@ -856,17 +813,15 @@ Map::types_within(MapPos pos, Terrain low, Terrain high) {
 bool
 Map::operator == (const Map& rhs) const {
   // Check fundamental properties
-  if (this->size != rhs.size ||
-      this->col_size != rhs.col_size ||
-      this->row_size != rhs.row_size ||
+  if (this->geom_ != rhs.geom_ ||
       this->regions != rhs.regions ||
       this->update_state != rhs.update_state) {
     return false;
   }
 
   // Check all tiles
-  for (unsigned int y = 0; y < rows; y++) {
-    for (unsigned int x = 0; x < cols; x++) {
+  for (unsigned int y = 0; y < geom_.rows(); y++) {
+    for (unsigned int x = 0; x < geom_.cols(); x++) {
       MapPos pos_ = pos(x, y);
       if (pos_ != rhs.pos(x, y)) return false;
 
@@ -892,8 +847,8 @@ operator >> (SaveReaderBinary &reader, Map &map) {
   uint8_t v8;
   uint16_t v16;
 
-  for (unsigned int y = 0; y < map.rows; y++) {
-    for (unsigned int x = 0; x < map.cols; x++) {
+  for (unsigned int y = 0; y < map.geom().rows(); y++) {
+    for (unsigned int x = 0; x < map.geom().cols(); x++) {
       MapPos pos = map.pos(x, y);
       reader >> v8;
       map.game_tiles[pos].paths = v8 & 0x3f;
@@ -907,7 +862,7 @@ operator >> (SaveReaderBinary &reader, Map &map) {
       map.landscape_tiles[pos].obj = (Map::Object)(v8 & 0x7f);
       map.game_tiles[pos].idle_serf = (BIT_TEST(v8, 7) != 0);
     }
-    for (unsigned int x = 0; x < map.cols; x++) {
+    for (unsigned int x = 0; x < map.geom().cols(); x++) {
       MapPos pos = map.pos(x, y);
       if (map.get_obj(pos) >= Map::ObjectFlag &&
           map.get_obj(pos) <= Map::ObjectCastle) {

--- a/src/map.h
+++ b/src/map.h
@@ -23,6 +23,7 @@
 #define SRC_MAP_H_
 
 #include <list>
+#include <memory>
 #include <utility>
 
 #include "src/map-geometry.h"
@@ -289,8 +290,8 @@ class Map {
   } GameTile;
 
   MapGeometry geom_;
-  LandscapeTile *landscape_tiles;
-  GameTile *game_tiles;
+  std::unique_ptr<LandscapeTile[]> landscape_tiles;
+  std::unique_ptr<GameTile[]> game_tiles;
 
   uint16_t regions;
 
@@ -300,11 +301,10 @@ class Map {
   typedef std::list<Handler*> change_handlers_t;
   change_handlers_t change_handlers;
 
-  MapPos *spiral_pos_pattern;
+  std::unique_ptr<MapPos[]> spiral_pos_pattern;
 
  public:
   explicit Map(const MapGeometry& geom);
-  virtual ~Map();
 
   const MapGeometry& geom() const { return geom_; }
 
@@ -455,8 +455,6 @@ class Map {
     operator << (SaveWriterText &writer, Map &map);
 
  protected:
-  void deinit();
-
   void init_spiral_pos_pattern();
 
   void update_public(MapPos pos, Random *rnd);

--- a/src/minimap.cc
+++ b/src/minimap.cc
@@ -88,20 +88,17 @@ Minimap::init_minimap() {
   memset(minimap, 0, size);
 
   uint8_t *mpos = minimap;
-  for (unsigned int y = 0; y < map->get_rows(); y++) {
-    for (unsigned int x = 0; x < map->get_cols(); x++) {
-      MapPos pos = map->pos(x, y);
-      int type_off = color_offset[map->type_up(pos)];
+  for (MapPos pos : map->geom()) {
+    int type_off = color_offset[map->type_up(pos)];
 
-      pos = map->move_right(pos);
-      int h1 = map->get_height(pos);
+    pos = map->move_right(pos);
+    int h1 = map->get_height(pos);
 
-      pos = map->move_down_left(pos);
-      int h2 = map->get_height(pos);
+    pos = map->move_down_left(pos);
+    int h2 = map->get_height(pos);
 
-      int h_off = h2 - h1 + 8;
-      *(mpos++) = colors[type_off + h_off];
-    }
+    int h_off = h2 - h1 + 8;
+    *(mpos++) = colors[type_off + h_off];
   }
 }
 

--- a/tests/test_map.cc
+++ b/tests/test_map.cc
@@ -27,6 +27,7 @@
 
 #include "src/map.h"
 #include "src/map-generator.h"
+#include "src/map-geometry.h"
 #include "src/random.h"
 
 
@@ -55,8 +56,8 @@ main(int argc, char *argv[]) {
   is.close();
 
   // Generate corresponding map
-  Map map;
-  map.init(map_size);
+  const MapGeometry geom(map_size);
+  Map map(geom);
 
   Random random = Random("8667715887436237");
 


### PR DESCRIPTION
First commit separates the map landscape/game tiles from the position/dimension/movement. The latter part is moved into the `MapGeometry` class. This should make it easier to test this part separately. The `Map` is changed to be constructed from a `MapGeometry` so more initialization of the `Map` is moved to the constructor.

Second commit adds an iterator over all `MapPos` in the map. This simplifies a number of loops that iterate linearly over the map. 

Third commit further cleans up construction and destruction of `Map` by using `unique_ptr` for memory management.