### PR TITLE
player: Fix init() taking unnecessary game object number

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -2114,8 +2114,7 @@ Game::add_player(size_t face, unsigned int color, unsigned int supplies,
   Player *player = players.allocate();
   if (player == NULL) abort();
 
-  player->init(player->get_index(), face, color, supplies, reproduction,
-               intelligence);
+  player->init(face, color, supplies, reproduction, intelligence);
 
   /* Update map values dependent on player count */
   map_gold_morale_factor = 10 * 1024 * static_cast<int>(players.size());
@@ -2827,7 +2826,7 @@ operator >> (SaveReaderText &reader, Game &game) {
   sections = reader.get_sections("player");
   for (Readers::iterator it = sections.begin(); it != sections.end(); ++it) {
     Player *p = game.players.get_or_insert((*it)->get_number());
-    p->init(0, 1, 0, 0, 0, 0);
+    p->init(1, 0, 0, 0, 0);
     **it >> *p;
   }
 

--- a/src/player.cc
+++ b/src/player.cc
@@ -34,9 +34,8 @@ Player::Player(Game *game, unsigned int index)
 }
 
 void
-Player::init(unsigned int number, size_t face, unsigned int color,
-             unsigned int supplies, size_t reproduction,
-             size_t intelligence) {
+Player::init(size_t face, unsigned int color, unsigned int supplies,
+             size_t reproduction, size_t intelligence) {
   flags = 0;
 
   if (face == 0) return;
@@ -47,7 +46,6 @@ Player::init(unsigned int number, size_t face, unsigned int color,
     /*game.max_next_index = 49;*/
   }
 
-  this->index = number;
   this->color = color;
   this->face = face;
   build = 0;

--- a/src/player.h
+++ b/src/player.h
@@ -166,9 +166,8 @@ class Player : public GameObject {
  public:
   Player(Game *game, unsigned int index);
 
-  void init(unsigned int number, size_t face, unsigned int color,
-            unsigned int supplies, size_t reproduction,
-            size_t intelligence);
+  void init(size_t face, unsigned int color, unsigned int supplies,
+            size_t reproduction, size_t intelligence);
 
   int get_color() const { return color; }
   size_t get_face() const { return face; }


### PR DESCRIPTION
The `init()` method on `Player` takes an argument which overwrites the game object number (`index`) on the parent class. This is unnecessary because the game object number is already assigned by the constructor and should not be changed. This bug became apparent after 06a0e3b was applied. When certain save games were loaded the game would freeze on quit.