### PR TITLE
map: Fix bug in call to on_object_changed()

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -410,7 +410,7 @@ Map::set_object(MapPos pos, Object obj, int index) {
   for (int d = DirectionRight; d <= DirectionUp; d++) {
     for (change_handlers_t::iterator it = change_handlers.begin();
          it != change_handlers.end(); ++it) {
-      (*it)->on_object_changed(pos);
+      (*it)->on_object_changed(move(pos, (Direction)d));
     }
   }
 }


### PR DESCRIPTION
This fixes an apparent bug in `set_object()` where the six directions are iterated to get the six positions surrounding the original position but `on_object_changed()` is called with the original positions resulting in six identical calls. I'm not entirely sure why this even has to call `on_object_changed()` on more than one position but for now this fix at least changes it to do something meaningful.