### PR TITLE
Handle game objects in Collection with smart pointer

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -57,7 +57,10 @@ Game::Game() {
 }
 
 Game::~Game() {
-  deinit();
+  if (map != NULL) {
+    delete map;
+    map = NULL;
+  }
 }
 
 /* Clear the serf request bit of all flags and buildings.
@@ -2161,39 +2164,6 @@ void
 Game::init_map_data(const MapGenerator& generator) {
   this->map->init_tiles(generator);
   gold_total = map->get_gold_deposit();
-}
-
-void
-Game::deinit() {
-  while (serfs.size()) {
-    Serfs::Iterator it = serfs.begin();
-    serfs.erase((*it)->get_index());
-  }
-
-  while (buildings.size()) {
-    Buildings::Iterator it = buildings.begin();
-    buildings.erase((*it)->get_index());
-  }
-
-  while (inventories.size()) {
-    Inventories::Iterator it = inventories.begin();
-    inventories.erase((*it)->get_index());
-  }
-
-  while (flags.size()) {
-    Flags::Iterator it = flags.begin();
-    flags.erase((*it)->get_index());
-  }
-
-  while (players.size()) {
-    Players::Iterator it = players.begin();
-    players.erase((*it)->get_index());
-  }
-
-  if (map != NULL) {
-    delete map;
-    map = NULL;
-  }
 }
 
 void

--- a/src/game.cc
+++ b/src/game.cc
@@ -39,14 +39,13 @@
 #include "src/log.h"
 #include "src/misc.h"
 #include "src/inventory.h"
+#include "src/map.h"
 #include "src/map-generator.h"
 #include "src/map-geometry.h"
 
 #define GROUND_ANALYSIS_RADIUS  25
 
 Game::Game() {
-  map = NULL;
-
   players = Players(this);
   flags = Flags(this);
   inventories = Inventories(this);
@@ -54,13 +53,6 @@ Game::Game() {
   serfs = Serfs(this);
 
   allocate_objects();
-}
-
-Game::~Game() {
-  if (map != NULL) {
-    delete map;
-    map = NULL;
-  }
 }
 
 /* Clear the serf request bit of all flags and buildings.
@@ -2152,12 +2144,7 @@ Game::init() {
 /* Initialize spiral_pos_pattern from spiral_pattern. */
 void
 Game::init_map(int size) {
-  if (map != NULL) {
-    delete map;
-    map = NULL;
-  }
-
-  map = new Map(MapGeometry(size));
+  map.reset(new Map(MapGeometry(size)));
 }
 
 void
@@ -2570,7 +2557,7 @@ operator >> (SaveReaderBinary &reader, Game &game) {
     throw ExceptionFreeserf("Invalid map size in file");
   }
 
-  game.map = new Map(MapGeometry(map_size));
+  game.map.reset(new Map(MapGeometry(map_size)));
 
   reader.skip(8);
   reader >> v16;  // 200
@@ -2736,7 +2723,7 @@ operator >> (SaveReaderText &reader, Game &game) {
   }
 
   /* Initialize remaining map dimensions. */
-  game.map = new Map(MapGeometry(size));
+  game.map.reset(new Map(MapGeometry(size)));
   sections = reader.get_sections("map");
   for (Readers::iterator it = sections.begin(); it != sections.end(); ++it) {
     **it >> *game.map;

--- a/src/game.h
+++ b/src/game.h
@@ -220,7 +220,6 @@ class Game : public EventLoop::Handler {
 
  protected:
   void allocate_objects();
-  void deinit();
 
   void clear_serf_request_failure();
   void update_knight_morale();

--- a/src/game.h
+++ b/src/game.h
@@ -27,10 +27,12 @@
 #include <map>
 #include <string>
 #include <list>
+#include <memory>
 
 #include "src/player.h"
 #include "src/flag.h"
 #include "src/serf.h"
+#include "src/inventory.h"
 #include "src/map.h"
 #include "src/random.h"
 #include "src/objects.h"
@@ -58,7 +60,7 @@ class Game : public EventLoop::Handler {
   typedef std::list<Inventory*> ListInventories;
 
  protected:
-  Map *map;
+  std::unique_ptr<Map> map;
 
   typedef std::map<unsigned int, unsigned int> values_t;
   int map_gold_morale_factor;
@@ -105,9 +107,9 @@ class Game : public EventLoop::Handler {
 
  public:
   Game();
-  virtual ~Game();
+  virtual ~Game() {}
 
-  Map *get_map() { return map; }
+  Map *get_map() { return map.get(); }
 
   unsigned int get_tick() const { return tick; }
   unsigned int get_const_tick() const { return const_tick; }

--- a/src/objects.h
+++ b/src/objects.h
@@ -60,7 +60,7 @@ class GameObject {
 template<class T>
 class Collection {
  protected:
-  typedef std::map<unsigned int, std::unique_ptr<T>> Objects;
+  typedef std::map<unsigned int, T> Objects;
 
   Objects objects;
   unsigned int last_object_index;
@@ -95,9 +95,9 @@ class Collection {
       last_object_index++;
     }
 
-    objects.emplace(new_index, std::unique_ptr<T>(new T(game, new_index)));
+    objects.emplace(new_index, T(game, new_index));
 
-    return objects[new_index].get();
+    return &objects.at(new_index);
   }
 
   bool
@@ -108,7 +108,7 @@ class Collection {
   T*
   get_or_insert(unsigned int index) {
     if (!exists(index)) {
-      objects.emplace(index, std::unique_ptr<T>(new T(game, index)));
+      objects.emplace(index, T(game, index));
 
       std::set<unsigned int>::iterator i = free_object_indexes.find(index);
       if (i != free_object_indexes.end()) {
@@ -123,20 +123,17 @@ class Collection {
       last_object_index = index + 1;
     }
 
-    return objects[index].get();
+    return &objects.at(index);
   }
 
-  T*
-  operator[] (unsigned int index) {
-    if (!exists(index)) {
-      return NULL;
-    }
-    return objects.at(index).get();
+  T* operator[] (unsigned int index) {
+    if (!exists(index)) return nullptr;
+    return &objects.at(index);
   }
 
   const T* operator[] (unsigned int index) const {
     if (!exists(index)) return nullptr;
-    return objects.at(index).get();
+    return &objects.at(index);
   }
 
   class Iterator {
@@ -164,9 +161,8 @@ class Collection {
       return (!(*this == right));
     }
 
-    T*
-    operator*() const {
-      return internal_iterator->second.get();
+    T* operator*() const {
+      return &internal_iterator->second;
     }
   };
 
@@ -193,7 +189,7 @@ class Collection {
     }
 
     const T* operator*() const {
-     return internal_iterator->second.get();
+     return &internal_iterator->second;
     }
   };
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <memory>
 #include <limits>
+#include <utility>
 
 class Game;
 
@@ -36,8 +37,21 @@ class GameObject {
   Game *game;
 
  public:
+  GameObject() = delete;
   GameObject(Game *game, unsigned int index) : index(index), game(game) {}
+  GameObject(const GameObject& that) = delete;
+  GameObject(GameObject&& that) : index(that.index), game(that.game) {
+    that.game = nullptr;
+    that.index = std::numeric_limits<unsigned int>::max();
+  }
   virtual ~GameObject() {}
+
+  GameObject& operator = (const GameObject& that) = delete;
+  GameObject& operator = (GameObject&& that) {
+    std::swap(this->index, that.index);
+    std::swap(this->game, that.game);
+    return *this;
+  }
 
   Game *get_game() const { return game; }
   unsigned int get_index() const { return index; }


### PR DESCRIPTION
First commit changes `Collection` to handle game objects with smart pointers. Second commit removes the calls to `erase()` in `Game::deinit()` since the smart pointers automatically free the game objects when the `Game` is destroyed. Third commit changes the `Map` instance in `Game` to also be handled with smart pointer.

Fourth and fifth commit change `GameObject` to be stored directly in the objects map of the `Collection`, avoiding the indirection through the smart pointer.