### PR TITLE
Direction iterator

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@
 bin_PROGRAMS = freeserf
 noinst_PROGRAMS = \
 	tests/test_map \
+	tests/test_map_geometry \
 	tests/test_save_game
 
 GAME_SOURCES = \
@@ -63,6 +64,10 @@ tests_test_save_game_SOURCES = \
 	tests/test_save_game.cc \
 	$(GAME_SOURCES)
 
+tests_test_map_geometry_SOURCES = \
+	tests/test_map_geometry.cc \
+	$(GAME_SOURCES)
+
 AM_CFLAGS = $(SDL2_CFLAGS) -I$(top_builddir)/src
 AM_CXXFLAGS = $(SDL2_CFLAGS) -I$(top_builddir)/src
 freeserf_LDADD = $(SDL2_LIBS) $(SDL2_CFLAGS) -lm
@@ -86,6 +91,7 @@ LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/tap-driver.sh
 TESTS = \
 	tests/test_map \
+	tests/test_map_geometry \
 	tests/test_save_game
 
 EXTRA_DIST = \

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -276,17 +276,16 @@ Interface::determine_map_cursor_type_road() {
   int h = game->get_map()->get_height(pos);
   int valid_dir = 0;
 
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
+  for (Direction d : cycle_directions_cw()) {
     int sprite = 0;
 
-    if (building_road.is_undo((Direction)d)) {
+    if (building_road.is_undo(d)) {
       sprite = 45; /* undo */
       valid_dir |= BIT(d);
-    } else if (game->get_map()->is_road_segment_valid(pos, (Direction)d)) {
-      if (building_road.is_valid_extension(game->get_map(), (Direction)d)) {
+    } else if (game->get_map()->is_road_segment_valid(pos, d)) {
+      if (building_road.is_valid_extension(game->get_map(), d)) {
         int h_diff =
-          game->get_map()->get_height(game->get_map()->move(pos,
-                                                            (Direction)d)) - h;
+          game->get_map()->get_height(game->get_map()->move(pos, d)) - h;
         sprite = 39 + h_diff; /* height indicators */
         valid_dir |= BIT(d);
       } else {

--- a/src/map-generator.cc
+++ b/src/map-generator.cc
@@ -306,8 +306,8 @@ bool
 ClassicMapGenerator::expand_water_position(MapPos pos_) {
   bool expanding = false;
 
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
-    MapPos new_pos = map.move(pos_, (Direction)d);
+  for (Direction d : cycle_directions_cw()) {
+    MapPos new_pos = map.move(pos_, d);
     unsigned int height = tiles[new_pos].height;
     if (water_level < height && height < 254) {
       return false;
@@ -319,8 +319,8 @@ ClassicMapGenerator::expand_water_position(MapPos pos_) {
   if (expanding) {
     tiles[pos_].height = 255;
 
-    for (int d = DirectionRight; d <= DirectionUp; d++) {
-      MapPos new_pos = map.move(pos_, (Direction)d);
+    for (Direction d : cycle_directions_cw()) {
+      MapPos new_pos = map.move(pos_, d);
       if (tiles[new_pos].height != 255) tiles[new_pos].height = 254;
     }
   }
@@ -335,8 +335,8 @@ ClassicMapGenerator::expand_water_position(MapPos pos_) {
 void
 ClassicMapGenerator::expand_water_body(MapPos pos) {
   // Check whether it is possible to expand from this position.
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
-    MapPos new_pos = map.move(pos, (Direction)d);
+  for (Direction d : cycle_directions_cw()) {
+    MapPos new_pos = map.move(pos, d);
     if (tiles[new_pos].height > water_level) {
       // Expanding water from this position was not possible. Just raise the
       // height to one above sea level.
@@ -347,8 +347,8 @@ ClassicMapGenerator::expand_water_body(MapPos pos) {
 
   // Initialize expansion
   tiles[pos].height = 255;
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
-    MapPos new_pos = map.move(pos, (Direction)d);
+  for (Direction d : cycle_directions_cw()) {
+    MapPos new_pos = map.move(pos, d);
     tiles[new_pos].height = 254;
   }
 
@@ -358,8 +358,7 @@ ClassicMapGenerator::expand_water_body(MapPos pos) {
     bool expanded = false;
 
     MapPos new_pos = map.move_right_n(pos, i+1);
-    for (int k = DirectionRight; k <= DirectionUp; k++) {
-      Direction d = turn_direction(DirectionDown, k);
+    for (Direction d : cycle_directions_cw(DirectionDown)) {
       for (unsigned int j = 0; j <= i; j++) {
         expanded |= expand_water_position(new_pos);
         new_pos = map.move(new_pos, d);
@@ -377,8 +376,7 @@ ClassicMapGenerator::expand_water_body(MapPos pos) {
 
   for (unsigned int i = 0; i < max_lake_area + 1; i++) {
     MapPos new_pos = map.move_right_n(pos, i+1);
-    for (int k = DirectionRight; k <= DirectionUp; k++) {
-      Direction d = (Direction)((k + DirectionDown) % 6);
+    for (Direction d : cycle_directions_cw(DirectionDown)) {
       for (unsigned int j = 0; j <= i; j++) {
         if (tiles[new_pos].height > 253) tiles[new_pos].height -= 2;
         new_pos = map.move(new_pos, d);
@@ -527,10 +525,10 @@ ClassicMapGenerator::remove_islands() {
             }
 
             // Mark positions following any valid direction on land.
-            for (int d = DirectionRight; d <= DirectionUp; d++) {
+            for (Direction d : cycle_directions_cw()) {
               if (BIT_TEST(flags, d)) {
-                if (tags[map.move(pos_, (Direction)d)] == 0) {
-                  tags[map.move(pos_, (Direction)d)] = 1;
+                if (tags[map.move(pos_, d)] == 0) {
+                  tags[map.move(pos_, d)] = 1;
                   changed = true;
                 }
               }
@@ -1048,8 +1046,8 @@ ClassicMapGenerator::clean_up() {
       // under two particular conditions at the map edge:
       // 1) x == 0 && d == DirectionLeft
       // 2) y == 0 && (d == DirectionUp || d == DirectionUpLeft)
-      for (int d = DirectionLeft; d <= DirectionUp; d++) {
-        MapPos other_pos = map.move(pos_, (Direction)d);
+      for (Direction d : cycle_directions_cw(DirectionLeft, 3)) {
+        MapPos other_pos = map.move(pos_, d);
         Map::Space s = Map::map_space_from_obj[tiles[other_pos].obj];
 
         bool check_impassable = false;

--- a/src/map.cc
+++ b/src/map.cc
@@ -390,10 +390,10 @@ Map::set_height(MapPos pos, int height) {
   landscape_tiles[pos].height = height;
 
   /* Mark landscape dirty */
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
+  for (Direction d : cycle_directions_cw()) {
     for (change_handlers_t::iterator it = change_handlers.begin();
          it != change_handlers.end(); ++it) {
-      (*it)->on_height_changed(move(pos, (Direction)d));
+      (*it)->on_height_changed(move(pos, d));
     }
   }
 }
@@ -407,10 +407,10 @@ Map::set_object(MapPos pos, Object obj, int index) {
   if (index >= 0) game_tiles[pos].obj_index = index;
 
   /* Notify about object change */
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
+  for (Direction d : cycle_directions_cw()) {
     for (change_handlers_t::iterator it = change_handlers.begin();
          it != change_handlers.end(); ++it) {
-      (*it)->on_object_changed(move(pos, (Direction)d));
+      (*it)->on_object_changed(move(pos, d));
     }
   }
 }
@@ -642,9 +642,9 @@ Map::remove_road_backref_until_flag(MapPos pos_, Direction dir) {
 
     /* Find next direction of path. */
     dir = DirectionNone;
-    for (int d = DirectionRight; d <= DirectionUp; d++) {
+    for (Direction d : cycle_directions_cw()) {
       if (BIT_TEST(paths(pos_), d)) {
-        dir = (Direction)d;
+        dir = d;
         break;
       }
     }
@@ -661,17 +661,20 @@ Map::remove_road_backrefs(MapPos pos_) {
 
   /* Find directions of path segments to be split. */
   Direction path_1_dir = DirectionNone;
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
-    if (BIT_TEST(paths(pos_), d)) {
-      path_1_dir = (Direction)d;
+  auto cycle = cycle_directions_cw();
+  auto it = cycle.begin();
+  for (; it != cycle.end(); ++it) {
+    if (BIT_TEST(paths(pos_), *it)) {
+      path_1_dir = *it;
       break;
     }
   }
 
   Direction path_2_dir = DirectionNone;
-  for (int d = path_1_dir+1; d <= DirectionUp; d++) {
-    if (BIT_TEST(paths(pos_), d)) {
-      path_2_dir = (Direction)d;
+  ++it;
+  for (; it != cycle.end(); ++it) {
+    if (BIT_TEST(paths(pos_), *it)) {
+      path_2_dir = *it;
       break;
     }
   }
@@ -695,9 +698,9 @@ Map::remove_road_segment(MapPos *pos, Direction dir) {
 
   /* Find next direction of path. */
   dir = DirectionNone;
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
+  for (Direction d : cycle_directions_cw()) {
     if (BIT_TEST(paths(*pos), d)) {
-      dir = (Direction)d;
+      dir = d;
       break;
     }
   }

--- a/src/pathfinder.cc
+++ b/src/pathfinder.cc
@@ -132,13 +132,12 @@ pathfinder_map(Map *map, MapPos start, MapPos end) {
     /* Put current node on closed list. */
     closed.push_front(node);
 
-    for (int d = DirectionRight; d <= DirectionUp; d++) {
-      MapPos new_pos = map->move(node->pos, (Direction)d);
-      unsigned int cost = actual_cost(map, node->pos,
-                                      static_cast<Direction>(d));
+    for (Direction d : cycle_directions_cw()) {
+      MapPos new_pos = map->move(node->pos, d);
+      unsigned int cost = actual_cost(map, node->pos, d);
 
       /* Check if neighbour is valid. */
-      if (!map->is_road_segment_valid(node->pos, static_cast<Direction>(d)) ||
+      if (!map->is_road_segment_valid(node->pos, d) ||
           (map->get_obj(new_pos) == Map::ObjectFlag && new_pos != start)) {
         continue;
       }
@@ -166,7 +165,7 @@ pathfinder_map(Map *map, MapPos start, MapPos end) {
             n->g_score = node->g_score + cost;
             n->f_score = n->g_score + heuristic_cost(map, new_pos, start);
             n->parent = node;
-            n->dir = static_cast<Direction>(d);
+            n->dir = d;
 
             // Move element to the back and heapify
             iter_swap(it, open.rbegin());
@@ -185,7 +184,7 @@ pathfinder_map(Map *map, MapPos start, MapPos end) {
         new_node->f_score = new_node->g_score +
                             heuristic_cost(map, new_pos, start);
         new_node->parent = node;
-        new_node->dir = static_cast<Direction>(d);
+        new_node->dir = d;
 
         open.push_back(new_node);
         std::push_heap(open.begin(), open.end(), search_node_less);

--- a/src/popup.cc
+++ b/src/popup.cc
@@ -2168,12 +2168,13 @@ PopupBox::draw_transport_info_box() {
   draw_popup_building(8, 40, 0x80 + 4*popup->interface->player->player_num);
 #endif
 
-  for (int i = DirectionRight; i <= DirectionUp; i++) {
-    int x = layout[2*i];
-    int y = layout[2*i+1];
-    if (flag->has_path((Direction)(5-i))) {
+  for (Direction d : cycle_directions_cw()) {
+    int index = 5 - d;
+    int x = layout[2*index];
+    int y = layout[2*index + 1];
+    if (flag->has_path(d)) {
       int sprite = 0xdc; /* Minus box */
-      if (flag->has_transporter((Direction)(5-i))) {
+      if (flag->has_transporter(d)) {
         sprite = 0x120; /* Check box */
       }
       draw_popup_icon(x, y, sprite);

--- a/src/serf.cc
+++ b/src/serf.cc
@@ -1239,10 +1239,10 @@ Serf::handle_serf_walking_state() {
       } else {
         Flag *src = game->get_flag_at_pos(pos);
         FlagSearch search(game);
-        for (int i = DirectionRight; i <= DirectionUp; i++) {
-          if (!src->is_water_path((Direction)(5-i))) {
-            Flag *other_flag = src->get_other_end_flag((Direction)(5-i));
-            other_flag->set_search_dir((Direction)(5-i));
+        for (Direction i : cycle_directions_ccw()) {
+          if (!src->is_water_path(i)) {
+            Flag *other_flag = src->get_other_end_flag(i);
+            other_flag->set_search_dir(i);
             search.add_source(other_flag);
           }
         }
@@ -1255,9 +1255,9 @@ Serf::handle_serf_walking_state() {
       /* Serf is not at a flag. Just follow the road. */
       int paths = game->get_map()->paths(pos) & ~BIT(s.walking.dir);
       Direction dir = DirectionNone;
-      for (int d = DirectionRight; d <= DirectionUp; d++) {
+      for (Direction d : cycle_directions_cw()) {
         if (paths == BIT(d)) {
-          dir = (Direction)d;
+          dir = d;
           break;
         }
       }
@@ -1346,9 +1346,9 @@ Serf::handle_serf_transporting_state() {
     } else {
       int paths = game->get_map()->paths(pos) & ~BIT(s.walking.dir);
       Direction dir = DirectionNone;
-      for (int d = DirectionRight; d <= DirectionUp; d++) {
+      for (Direction d : cycle_directions_cw()) {
         if (paths == BIT(d)) {
-          dir = (Direction)d;
+          dir = d;
           break;
         }
       }
@@ -2691,16 +2691,16 @@ Serf::handle_serf_free_walking_switch_with_other() {
   MapPos new_pos = 0;
   Direction dir = DirectionNone;
   Serf *other_serf = NULL;
-  for (int i = DirectionRight; i <= DirectionUp; i++) {
-    new_pos = game->get_map()->move(pos, (Direction)i);
+  for (Direction i : cycle_directions_cw()) {
+    new_pos = game->get_map()->move(pos, i);
     if (game->get_map()->has_serf(new_pos)) {
       other_serf = game->get_serf_at_pos(new_pos);
       Direction other_dir;
 
       if (other_serf->is_waiting(&other_dir) &&
-          other_dir == reverse_direction((Direction)i) &&
+          other_dir == reverse_direction(i) &&
           other_serf->switch_waiting(other_dir)) {
-        dir = (Direction)i;
+        dir = i;
         break;
       }
     }
@@ -2842,13 +2842,13 @@ Serf::handle_free_walking_follow_edge() {
   const Direction *a0 = &dir_arr[6*dir_index];
   Direction i0 = DirectionNone;
   Direction dir = DirectionNone;
-  for (int i = DirectionRight; i <= DirectionUp; i++) {
+  for (Direction i : cycle_directions_cw()) {
     MapPos new_pos = game->get_map()->move(pos, a0[i]);
     if (((water && game->get_map()->get_obj(new_pos) == 0) ||
          (!water && !game->get_map()->is_in_water(new_pos) &&
           can_pass_map_pos(new_pos))) && !game->get_map()->has_serf(new_pos)) {
       dir = a0[i];
-      i0 = (Direction)i;
+      i0 = i;
       break;
     }
   }
@@ -4699,8 +4699,8 @@ Serf::handle_state_knight_free_walking() {
 
   while (counter < 0) {
     /* Check for enemy knights nearby. */
-    for (int d = DirectionRight; d <= DirectionUp; d++) {
-      MapPos pos_ = game->get_map()->move(pos, (Direction)d);
+    for (Direction d : cycle_directions_cw()) {
+      MapPos pos_ = game->get_map()->move(pos, d);
 
       if (game->get_map()->has_serf(pos_)) {
         Serf *other = game->get_serf_at_pos(pos_);
@@ -5119,7 +5119,7 @@ void
 Serf::handle_serf_wake_on_path_state() {
   set_state(StateWaitIdleOnPath);
 
-  for (int d = DirectionUp; d >= DirectionRight; d--) {
+  for (Direction d : cycle_directions_ccw()) {
     if (BIT_TEST(game->get_map()->paths(pos), d)) {
       s.idle_on_path.field_E = d;
       break;

--- a/src/viewport.cc
+++ b/src/viewport.cc
@@ -534,14 +534,14 @@ Viewport::draw_paths_and_borders() {
 
       /* For each direction right, down right and down,
          draw the corresponding paths and borders. */
-      for (int d = DirectionRight; d <= DirectionDown; d++) {
-        MapPos other_pos = map->move(pos, (Direction)d);
+      for (Direction d : cycle_directions_cw(DirectionRight, 3)) {
+        MapPos other_pos = map->move(pos, d);
 
-        if (map->has_path(pos, (Direction)d)) {
-          draw_path_segment(x, y_base, pos, (Direction)d);
+        if (map->has_path(pos, d)) {
+          draw_path_segment(x, y_base, pos, d);
         } else if (map->has_owner(pos) != map->has_owner(other_pos) ||
                    map->get_owner(pos) != map->get_owner(other_pos)) {
-          draw_border_segment(x, y_base, pos, (Direction)d);
+          draw_border_segment(x, y_base, pos, d);
         }
       }
 
@@ -2171,9 +2171,8 @@ Viewport::draw_map_cursor() {
   draw_map_cursor_sprite(interface->get_map_cursor_pos(),
                          interface->get_map_cursor_sprite(0));
 
-  for (int d = DirectionRight; d <= DirectionUp; d++) {
-    draw_map_cursor_sprite(map->move(interface->get_map_cursor_pos(),
-                                     (Direction)d),
+  for (Direction d : cycle_directions_cw()) {
+    draw_map_cursor_sprite(map->move(interface->get_map_cursor_pos(), d),
                            interface->get_map_cursor_sprite(1+d));
   }
 }

--- a/tests/test_map_geometry.cc
+++ b/tests/test_map_geometry.cc
@@ -1,0 +1,107 @@
+/*
+ * test_map_geometry.cc - TAP test for map geometry
+ *
+ * Copyright (C) 2016  Jon Lund Steffensen <jonlst@gmail.com>
+ *
+ * This file is part of freeserf.
+ *
+ * freeserf is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * freeserf is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with freeserf.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <vector>
+
+#include "src/map-geometry.h"
+
+int
+main(int argc, char *argv[]) {
+  // Print number of tests for TAP
+  std::cout << "1..4" << "\n";
+
+  {
+    // Test standard direction cycle
+    std::vector<Direction> dirs;
+    for (Direction d : cycle_directions_cw()) {
+      dirs.push_back(d);
+    }
+
+    std::vector<Direction> expected{
+      DirectionRight, DirectionDownRight, DirectionDown,
+      DirectionLeft, DirectionUpLeft, DirectionUp
+    };
+
+    if (dirs == expected) {
+      std::cout << "ok 1 - Correct directions produced\n";
+    } else {
+      std::cout << "not ok 1 - Incorrect directions produced\n";
+    }
+  }
+
+  {
+    // Test standard counter-clockwise direction cycle
+    std::vector<Direction> dirs;
+    for (Direction d : cycle_directions_ccw()) {
+      dirs.push_back(d);
+    }
+
+    std::vector<Direction> expected{
+      DirectionUp, DirectionUpLeft, DirectionLeft,
+      DirectionDown, DirectionDownRight, DirectionRight
+    };
+
+    if (dirs == expected) {
+      std::cout << "ok 2 - Correct directions produced\n";
+    } else {
+      std::cout << "not ok 2 - Incorrect directions produced\n";
+    }
+  }
+
+  {
+    // Test shorter clockwise cycle
+    std::vector<Direction> dirs;
+    for (Direction d : cycle_directions_cw(DirectionLeft, 4)) {
+      dirs.push_back(d);
+    }
+
+    std::vector<Direction> expected{
+      DirectionLeft, DirectionUpLeft, DirectionUp, DirectionRight
+    };
+
+    if (dirs == expected) {
+      std::cout << "ok 3 - Correct directions produced\n";
+    } else {
+      std::cout << "not ok 3 - Incorrect directions produced\n";
+    }
+  }
+
+  {
+    // Test longer counter-clockwise cycle
+    std::vector<Direction> dirs;
+    for (Direction d : cycle_directions_ccw(DirectionLeft, 10)) {
+      dirs.push_back(d);
+    }
+
+    std::vector<Direction> expected{
+      DirectionLeft, DirectionDown, DirectionDownRight, DirectionRight,
+      DirectionUp, DirectionUpLeft, DirectionLeft, DirectionDown,
+      DirectionDownRight, DirectionRight
+    };
+
+    if (dirs == expected) {
+      std::cout << "ok 4 - Correct directions produced\n";
+    } else {
+      std::cout << "not ok 4 - Incorrect directions produced\n";
+    }
+  }
+}


### PR DESCRIPTION
Adds iterator to cycle through directions. Simplifies many loops because the syntax is easier and safer than manually looping through the `Direction` enum and the iterator provides correctly typed values that don't need to be cast manually to `Direction`.