### PR TITLE
map-geometry: Remove non-standard directions

### DIFF
--- a/src/flag.cc
+++ b/src/flag.cc
@@ -428,7 +428,7 @@ Flag::schedule_slot_to_known_dest(int slot, unsigned int res_waiting[4]) {
   FlagSearch search(game);
 
   search_num = search.get_id();
-  search_dir = DirectionUpRight;
+  search_dir = DirectionNone;
   int tr = transporters();
 
   int sources = 0;
@@ -489,7 +489,7 @@ Flag::schedule_slot_to_known_dest(int slot, unsigned int res_waiting[4]) {
     data.dest = game->get_flag(this->slot[slot].dest);
     data.slot = slot;
     bool r = search.execute(schedule_known_dest_cb, false, true, &data);
-    if (!r || data.dest->search_dir == 6) {
+    if (!r || data.dest == this) {
       /* Unable to deliver */
       game->cancel_transported_resource(this->slot[slot].type,
                                         this->slot[slot].dest);

--- a/src/map-generator.cc
+++ b/src/map-generator.cc
@@ -592,7 +592,7 @@ ClassicMapGenerator::seed_terrain_type(Map::Terrain old, Map::Terrain seed,
          seed == tiles[map.move_left(pos_)].type_up ||
          seed == tiles[pos_].type_down ||
          seed == tiles[map.move_right(pos_)].type_up ||
-         seed == tiles[map.move_down_left(pos_)].type_down ||
+         seed == tiles[map.move_left(map.move_down(pos_))].type_down ||
          seed == tiles[map.move_down(pos_)].type_down ||
          seed == tiles[map.move_down(pos_)].type_up ||
          seed == tiles[map.move_down_right(pos_)].type_down ||
@@ -615,7 +615,7 @@ ClassicMapGenerator::seed_terrain_type(Map::Terrain old, Map::Terrain seed,
          seed == tiles[map.move_up_left(pos_)].type_up ||
          seed == tiles[map.move_up(pos_)].type_down ||
          seed == tiles[map.move_up(pos_)].type_up ||
-         seed == tiles[map.move_up_right(pos_)].type_up ||
+         seed == tiles[map.move_right(map.move_up(pos_))].type_up ||
          seed == tiles[map.move_left(pos_)].type_down ||
          seed == tiles[pos_].type_up ||
          seed == tiles[map.move_right(pos_)].type_down ||

--- a/src/map-geometry.h
+++ b/src/map-geometry.h
@@ -53,9 +53,6 @@ typedef enum Direction {
   DirectionLeft,
   DirectionUpLeft,
   DirectionUp,
-
-  DirectionUpRight,
-  DirectionDownLeft
 } Direction;
 
 // Return the given direction turned clockwise a number of times.
@@ -64,17 +61,14 @@ typedef enum Direction {
 // clockwise in 60 degree increment the specified number of times.
 // If times is a negative number the direction will be turned counter
 // clockwise.
-//
-// NOTE: Only valid for the six standard directions.
 inline Direction turn_direction(Direction d, int times) {
+  assert(d != DirectionNone);
   int td = (static_cast<int>(d) + times) % 6;
   if (td < 0) td += 6;
   return static_cast<Direction>(td);
 }
 
 // Return the given direction reversed.
-//
-// NOTE: Only valid for the six standard directions.
 inline Direction reverse_direction(Direction d) {
   return turn_direction(d, 3);
 }
@@ -115,7 +109,9 @@ class DirectionCycle {
   };
 
   DirectionCycle(Direction start, unsigned int length)
-      : start(start), length(length) {}
+      : start(start), length(length) {
+    assert(start != DirectionNone);
+  }
   DirectionCycle(const DirectionCycle& that)
       : start(that.start), length(that.length) {}
 
@@ -169,7 +165,7 @@ class MapGeometry {
   unsigned int size_;
 
   // Derived members
-  MapPos dirs[8];
+  MapPos dirs[6];
   unsigned int col_size_, row_size_;
 
   unsigned int cols_, rows_;
@@ -231,8 +227,6 @@ class MapGeometry {
     dirs[DirectionUp] = (-1 & row_mask_) << row_shift_;
 
     dirs[DirectionDownRight] = dirs[DirectionRight] | dirs[DirectionDown];
-    dirs[DirectionUpRight] = dirs[DirectionRight] | dirs[DirectionUp];
-    dirs[DirectionDownLeft] = dirs[DirectionLeft] | dirs[DirectionDown];
     dirs[DirectionUpLeft] = dirs[DirectionLeft] | dirs[DirectionUp];
   }
   MapGeometry(const MapGeometry& that) : MapGeometry(that.size_) {}
@@ -268,11 +262,6 @@ class MapGeometry {
   MapPos move_left(MapPos pos) const { return move(pos, DirectionLeft); }
   MapPos move_up_left(MapPos pos) const { return move(pos, DirectionUpLeft); }
   MapPos move_up(MapPos pos) const { return move(pos, DirectionUp); }
-
-  MapPos move_up_right(MapPos pos) const {
-    return move(pos, DirectionUpRight); }
-  MapPos move_down_left(MapPos pos) const {
-    return move(pos, DirectionDownLeft); }
 
   MapPos move_right_n(MapPos pos, int n) const {
     return pos_add(pos, dirs[DirectionRight]*n); }

--- a/src/map.h
+++ b/src/map.h
@@ -344,9 +344,6 @@ class Map {
   MapPos move_up_left(MapPos pos) const { return geom_.move_up_left(pos); }
   MapPos move_up(MapPos pos) const { return geom_.move_up(pos); }
 
-  MapPos move_up_right(MapPos pos) const { return geom_.move_up_right(pos); }
-  MapPos move_down_left(MapPos pos) const { return geom_.move_down_left(pos); }
-
   MapPos move_right_n(MapPos pos, int n) const {
     return geom_.move_right_n(pos, n); }
   MapPos move_down_n(MapPos pos, int n) const {

--- a/src/minimap.cc
+++ b/src/minimap.cc
@@ -78,7 +78,7 @@ Minimap::init_minimap() {
     pos = map->move_right(pos);
     int h1 = map->get_height(pos);
 
-    pos = map->move_down_left(pos);
+    pos = map->move_left(map->move_down(pos));
     int h2 = map->get_height(pos);
 
     int h_off = h2 - h1 + 8;


### PR DESCRIPTION
Remove `DirectionUpRight` and `DirectionDownLeft` from the `Direction` enum. These two directions are the non-standard directions because they do not correspond to a tile edge on the map that can be traversed. These directions were only used in a few places for movement and were easily converted to two standard direction movements.