### PR TITLE
Various data.cc cleanup

### DIFF
--- a/src/data.cc
+++ b/src/data.cc
@@ -133,3 +133,72 @@ Data::load(const std::string &path) {
 
   return data_source.get() != nullptr;
 }
+
+// Return standard game data search paths for current platform.
+std::list<std::string>
+Data::get_standard_search_paths() const {
+  // Data files are searched for in some common directories, some of which are
+  // specific to the platform we're running on.
+  //
+  // On platforms where the XDG specification applies, the data file is
+  // searched for in the directories specified by the
+  // XDG Base Directory Specification
+  // <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>.
+  //
+  // On Windows platforms the %localappdata% is used in place of
+  // XDG_DATA_HOME.
+
+  std::list<std::string> paths;
+
+  // Add path where base is obtained from an environment variable and can
+  // be nullptr or empty.
+  auto add_env_path = [&](const char* base, const char* suffix) {
+    if (base != nullptr) {
+      std::string b(base);
+      if (!b.empty()) paths.push_back(b + "/" + suffix);
+    }
+  };
+
+  // Look in current directory
+  paths.push_back(".");
+
+  // Look in data directories under the home directory
+  add_env_path(std::getenv("XDG_DATA_HOME"), "freeserf");
+  add_env_path(std::getenv("HOME"), ".local/share/freeserf");
+
+#ifdef _WIN32
+  // Look in the same directory as the freeserf.exe app.
+  char app_path[MAX_PATH + 1];
+  GetModuleFileNameA(NULL, app_path, MAX_PATH);
+  add_env_path(app_path, "../");
+
+  // Look in windows XDG_DATA_HOME equivalents.
+  add_env_path(std::getenv("userprofile"), ".local/share/freeserf");
+  add_env_path(std::getenv("LOCALAPPDATA"), "freeserf");
+#endif
+
+  // Search in global directories.
+#ifdef _WIN32
+  const char *env = std::getenv("PATH");
+  #define PATH_SEPERATING_CHAR ';'
+#else
+  const char *env = std::getenv("XDG_DATA_DIRS");
+  #define PATH_SEPERATING_CHAR ':'
+#endif
+
+  std::string dirs = (env == NULL) ? std::string() : env;
+  size_t next_path = 0;
+  while (next_path != std::string::npos) {
+    size_t pos = dirs.find(PATH_SEPERATING_CHAR, next_path);
+    std::string dir = dirs.substr(next_path, pos);
+    next_path = (pos != std::string::npos) ? pos + 1 : pos;
+    add_env_path(dir.c_str(), "freeserf");
+  }
+
+#ifndef _WIN32
+  paths.push_back("/usr/local/share/freeserf");
+  paths.push_back("/usr/share/freeserf");
+#endif
+
+  return paths;
+}

--- a/src/data.cc
+++ b/src/data.cc
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <vector>
 #include <memory>
+#include <utility>
 
 #include "src/log.h"
 #include "src/data-source-dos.h"
@@ -34,16 +35,7 @@
 #endif
 
 
-Data::Data() {
-  data_source = NULL;
-}
-
-Data::~Data() {
-  if (data_source != NULL) {
-    delete data_source;
-    data_source = NULL;
-  }
-}
+Data::Data() : data_source(nullptr) {}
 
 Data *
 Data::get_instance() {
@@ -129,15 +121,15 @@ Data::load(const std::string &path) {
         Log::Info["data"] << "Game data found in '"
                           << res_path.c_str() << "'...";
         if (ds->load(res_path)) {
-          data_source = ds.release();
+          data_source = std::move(ds);
           break;
         }
       }
     }
-    if (data_source != NULL) {
+    if (data_source) {
       break;
     }
   }
 
-  return (data_source != NULL);
+  return data_source.get() != nullptr;
 }

--- a/src/data.cc
+++ b/src/data.cc
@@ -74,8 +74,6 @@ Data::add_to_search_paths(const char *path,
   search_paths.push_back(res_path);
 }
 
-#define MAX_DATA_PATH      1024
-
 bool
 Data::load(const std::string &path) {
   /* If it possible, prefer DOS game data. */

--- a/src/data.cc
+++ b/src/data.cc
@@ -32,12 +32,8 @@
 #endif
 
 
-Data *
-Data::instance = NULL;
-
 Data::Data() {
   data_source = NULL;
-  instance = this;
 }
 
 Data::~Data() {
@@ -45,17 +41,12 @@ Data::~Data() {
     delete data_source;
     data_source = NULL;
   }
-
-  instance = NULL;
 }
 
 Data *
 Data::get_instance() {
-  if (instance == NULL) {
-    instance = new Data();
-  }
-
-  return instance;
+  static Data instance;
+  return &instance;
 }
 
 void

--- a/src/data.h
+++ b/src/data.h
@@ -24,6 +24,9 @@
 
 #include <string>
 #include <list>
+#include <memory>
+
+#include "src/data-source.h"
 
 /* Index 0 is undefined (entry 0 in the data file
    contains a header with the size and total
@@ -233,18 +236,16 @@
 
 #define DATA_CURSOR  3999
 
-class DataSource;
-
 class Data {
  protected:
-  DataSource *data_source;
+  std::unique_ptr<DataSource> data_source;
   std::list<std::string> search_paths;
 
   Data();
 
  public:
   Data(const Data& that) = delete;
-  virtual ~Data();
+  virtual ~Data() {}
 
   Data& operator = (const Data& that) = delete;
 
@@ -252,7 +253,7 @@ class Data {
 
   bool load(const std::string &path);
 
-  DataSource *get_data_source() const { return data_source; }
+  DataSource *get_data_source() const { return data_source.get(); }
 
  protected:
   void add_to_search_paths(const char *path, const char *suffix);

--- a/src/data.h
+++ b/src/data.h
@@ -237,7 +237,6 @@ class DataSource;
 
 class Data {
  protected:
-  static Data *instance;
   DataSource *data_source;
   std::list<std::string> search_paths;
 

--- a/src/data.h
+++ b/src/data.h
@@ -239,7 +239,6 @@
 class Data {
  protected:
   std::unique_ptr<DataSource> data_source;
-  std::list<std::string> search_paths;
 
   Data();
 
@@ -251,13 +250,12 @@ class Data {
 
   static Data *get_instance();
 
-  bool load(const std::string &path);
+  bool load(const std::string* path);
 
   DataSource *get_data_source() const { return data_source.get(); }
 
  protected:
   std::list<std::string> get_standard_search_paths() const;
-  void add_to_search_paths(const char *path, const char *suffix);
 };
 
 #endif  // SRC_DATA_H_

--- a/src/data.h
+++ b/src/data.h
@@ -256,6 +256,7 @@ class Data {
   DataSource *get_data_source() const { return data_source.get(); }
 
  protected:
+  std::list<std::string> get_standard_search_paths() const;
   void add_to_search_paths(const char *path, const char *suffix);
 };
 

--- a/src/data.h
+++ b/src/data.h
@@ -244,7 +244,10 @@ class Data {
   Data();
 
  public:
+  Data(const Data& that) = delete;
   virtual ~Data();
+
+  Data& operator = (const Data& that) = delete;
 
   static Data *get_instance();
 

--- a/src/freeserf.cc
+++ b/src/freeserf.cc
@@ -127,7 +127,6 @@ main(int argc, char *argv[]) {
 
   Data *data = Data::get_instance();
   if (!data->load(data_file)) {
-    delete data;
     Log::Error["main"] << "Could not load game data.";
     exit(EXIT_FAILURE);
   }
@@ -199,7 +198,6 @@ main(int argc, char *argv[]) {
   }
   delete audio;
   delete gfx;
-  delete data;
   delete event_loop;
 
   return EXIT_SUCCESS;

--- a/src/freeserf.cc
+++ b/src/freeserf.cc
@@ -58,7 +58,7 @@
   USAGE                                                     \
       " -d NUM\t\tSet debug output level\n"                 \
       " -f\t\tFullscreen mode (CTRL-q to exit)\n"           \
-      " -g DATA-FILE\tUse specified data file\n"            \
+      " -g DATA-FILE\tUse specified data directory\n"       \
       " -h\t\tShow this help text\n"                        \
       " -l FILE\tLoad saved game\n"                         \
       " -r RES\t\tSet display resolution (e.g. 800x600)\n"  \
@@ -68,7 +68,7 @@
 
 int
 main(int argc, char *argv[]) {
-  std::string data_file;
+  std::string data_dir;
   std::string save_file;
 
   int screen_width = DEFAULT_SCREEN_WIDTH;
@@ -93,7 +93,7 @@ main(int argc, char *argv[]) {
         break;
       case 'g':
         if (strlen(optarg) > 0) {
-          data_file = optarg;
+          data_dir = optarg;
         }
         break;
       case 'h':
@@ -126,7 +126,7 @@ main(int argc, char *argv[]) {
   Log::Info["main"] << "freeserf " << FREESERF_VERSION;
 
   Data *data = Data::get_instance();
-  if (!data->load(data_file)) {
+  if (!data->load(&data_dir)) {
     Log::Error["main"] << "Could not load game data.";
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
- Make sure that the singleton instance of `Data` is never copied and that it is always destroyed.
- Handle memory with smart pointer.
- Move the functionality that gathers standard search paths to separate method. Fixes a bug where the root directory (`/`) would be searched for data files.
- Restore functionality where standard paths are only searched if a nullptr/empty string is given.
- Add documentation and update usage help message shown when running `freeserf -h`.