### PR TITLE
Getting rid of 'dynamic exception specifications are deprecated in C++11' warnings

### DIFF
--- a/src/audio-sdlmixer.cc
+++ b/src/audio-sdlmixer.cc
@@ -46,7 +46,7 @@ Audio::get_instance() {
   return instance;
 }
 
-AudioSDL::AudioSDL() throw(ExceptionAudio) {
+AudioSDL::AudioSDL() {
   Log::Info["audio"] << "Initializing audio driver `sdlmixer'.";
 
   if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_TIMER) != 0) {

--- a/src/audio-sdlmixer.h
+++ b/src/audio-sdlmixer.h
@@ -127,7 +127,7 @@ class AudioSDL : public Audio, public Audio::VolumeController {
 
  public:
   /* Common audio. */
-  AudioSDL() throw(ExceptionAudio);
+  AudioSDL();
   virtual ~AudioSDL();
 
   virtual Audio::VolumeController *get_volume_controller() { return this; }

--- a/src/audio.h
+++ b/src/audio.h
@@ -135,7 +135,7 @@ class Audio {
 
   float volume;
 
-  Audio() throw(ExceptionAudio) {}
+  Audio() {}
 
  public:
   /* Common audio. */

--- a/src/gfx.cc
+++ b/src/gfx.cc
@@ -85,7 +85,7 @@ Image::clear_cache() {
 
 Graphics *Graphics::instance = NULL;
 
-Graphics::Graphics() throw(ExceptionFreeserf) {
+Graphics::Graphics() {
   if (instance != NULL) {
     throw ExceptionGFX("Unable to create second instance.");
   }

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -163,7 +163,7 @@ class Graphics {
   static Graphics *instance;
   Video *video;
 
-  Graphics() throw(ExceptionFreeserf);
+  Graphics();
 
  public:
   virtual ~Graphics();

--- a/src/savegame.cc
+++ b/src/savegame.cc
@@ -136,7 +136,7 @@ class SaveReaderTextSection : public SaveReaderText {
   }
 
   virtual SaveReaderTextValue
-  value(const std::string &name) const throw(ExceptionFreeserf) {
+  value(const std::string &name) const {
     Values::const_iterator it = values.find(name);
     if (it == values.end()) {
       std::ostringstream str;
@@ -209,7 +209,7 @@ class SaveReaderTextFile : public SaveReaderText {
   }
 
   virtual SaveReaderTextValue
-  value(const std::string &name) const throw(ExceptionFreeserf) {
+  value(const std::string &name) const {
     ReaderSections result;
 
     for (const SaveReaderTextSection *reader : sections) {

--- a/src/savegame.h
+++ b/src/savegame.h
@@ -105,8 +105,7 @@ class SaveReaderText {
   virtual ~SaveReaderText() = default;
   virtual std::string get_name() const = 0;
   virtual unsigned int get_number() const = 0;
-  virtual SaveReaderTextValue value(const std::string &name) const
-            throw(ExceptionFreeserf) = 0;
+  virtual SaveReaderTextValue value(const std::string &name) const = 0;
   virtual Readers get_sections(const std::string &name) = 0;
 };
 

--- a/src/video-sdl.cc
+++ b/src/video-sdl.cc
@@ -38,7 +38,7 @@ Uint32 VideoSDL::Bmask = 0xFF000000;
 Uint32 VideoSDL::Amask = 0x000000FF;
 Uint32 VideoSDL::pixel_format = SDL_PIXELFORMAT_RGBA8888;
 
-VideoSDL::VideoSDL() throw(ExceptionVideo) {
+VideoSDL::VideoSDL() {
   screen = NULL;
   cursor = NULL;
   fullscreen = false;
@@ -113,7 +113,7 @@ VideoSDL::create_surface(int width, int height) {
 
 void
 VideoSDL::set_resolution(unsigned int width, unsigned int height,
-                            bool fullscreen) throw(ExceptionVideo) {
+                            bool fullscreen) {
   /* Set fullscreen mode */
   int r = SDL_SetWindowFullscreen(window,
                                   fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP :
@@ -155,7 +155,7 @@ VideoSDL::get_resolution(unsigned int *width, unsigned int *height) {
 }
 
 void
-VideoSDL::set_fullscreen(bool enable) throw(ExceptionVideo) {
+VideoSDL::set_fullscreen(bool enable) {
   int width = 0;
   int height = 0;
   SDL_GetRendererOutputSize(renderer, &width, &height);

--- a/src/video-sdl.h
+++ b/src/video-sdl.h
@@ -73,13 +73,13 @@ class VideoSDL : public Video {
   float zoom_factor;
 
  public:
-  VideoSDL() throw(ExceptionVideo);
+  VideoSDL();
   virtual ~VideoSDL();
 
   virtual void set_resolution(unsigned int width, unsigned int height,
-                              bool fullscreen) throw(ExceptionVideo);
+                              bool fullscreen);
   virtual void get_resolution(unsigned int *width, unsigned int *height);
-  virtual void set_fullscreen(bool enable) throw(ExceptionVideo);
+  virtual void set_fullscreen(bool enable);
   virtual bool is_fullscreen();
 
   virtual Video::Frame *get_screen_frame();

--- a/src/video.cc
+++ b/src/video.cc
@@ -23,11 +23,11 @@
 
 #include <sstream>
 
-ExceptionVideo::ExceptionVideo(const std::string &description) throw() :
+ExceptionVideo::ExceptionVideo(const std::string &description) :
   ExceptionFreeserf(description) {
 }
 
-ExceptionVideo::~ExceptionVideo() throw() {
+ExceptionVideo::~ExceptionVideo() {
 }
 
 std::string
@@ -37,7 +37,7 @@ ExceptionVideo::get_description() const {
 
 Video *Video::instance = NULL;
 
-Video::Video() throw(ExceptionVideo) {
+Video::Video() {
   if (instance != NULL) {
     throw ExceptionVideo("Unable to create second instance.");
   }

--- a/src/video.h
+++ b/src/video.h
@@ -29,8 +29,8 @@
 
 class ExceptionVideo : public ExceptionFreeserf {
  public:
-  explicit ExceptionVideo(const std::string &description) throw();
-  virtual ~ExceptionVideo() throw();
+  explicit ExceptionVideo(const std::string &description);
+  virtual ~ExceptionVideo();
 
   virtual std::string get_description() const;
   virtual std::string get_platform() const { return "Abstract"; }
@@ -52,7 +52,7 @@ class Video {
  protected:
   static Video *instance;
 
-  Video() throw(ExceptionVideo);
+  Video();
 
  public:
   virtual ~Video();
@@ -60,9 +60,9 @@ class Video {
   static Video *get_instance();
 
   virtual void set_resolution(unsigned int width, unsigned int height,
-                              bool fullscreen) throw(ExceptionVideo) = 0;
+                              bool fullscreen) = 0;
   virtual void get_resolution(unsigned int *width, unsigned int *height) = 0;
-  virtual void set_fullscreen(bool enable) throw(ExceptionVideo) = 0;
+  virtual void set_fullscreen(bool enable) = 0;
   virtual bool is_fullscreen() = 0;
 
   virtual Frame *get_screen_frame() = 0;


### PR DESCRIPTION
Guys, this is deprecated for 6 years. Why are you still using this?