### PR TITLE
Fix #375: Save game functionality does not work in v0.2 and last build version

### DIFF
--- a/src/flag.cc
+++ b/src/flag.cc
@@ -136,15 +136,19 @@ Flag::del_path(Direction dir) {
 }
 
 bool
-Flag::pick_up_resource(int slot, Resource::Type *res, unsigned int *dest) {
-  if (this->slot[slot].type == Resource::TypeNone) {
+Flag::pick_up_resource(unsigned int from_slot, Resource::Type *res, unsigned int *dest) {
+  if (from_slot >= FLAG_MAX_RES_COUNT) {
+    throw ExceptionFreeserf("Wrong flag slot index.");
+  }
+
+  if (slot[from_slot].type == Resource::TypeNone) {
     return false;
   }
 
-  *res = this->slot[slot].type;
-  *dest = this->slot[slot].dest;
-  this->slot[slot].type = Resource::TypeNone;
-  this->slot[slot].dir = DirectionNone;
+  *res = slot[from_slot].type;
+  *dest = slot[from_slot].dest;
+  slot[from_slot].type = Resource::TypeNone;
+  slot[from_slot].dir = DirectionNone;
 
   fix_scheduled();
 
@@ -153,6 +157,10 @@ Flag::pick_up_resource(int slot, Resource::Type *res, unsigned int *dest) {
 
 bool
 Flag::drop_resource(Resource::Type res, unsigned int dest) {
+  if (res < Resource::TypeNone || res > Resource::GroupFood) {
+    throw ExceptionFreeserf("Wrong resource type.");
+  }
+
   for (int i = 0; i < FLAG_MAX_RES_COUNT; i++) {
     if (slot[i].type == Resource::TypeNone) {
       slot[i].type = res;
@@ -686,7 +694,7 @@ Flag::fill_path_serf_info(Game *game, MapPos pos, Direction dir,
 
   /* Trace along the path to the flag at the other end. */
   int paths = 0;
-  while (1) {
+  while (true) {
     path_len += 1;
     pos = map->move(pos, dir);
     paths = map->paths(pos);

--- a/src/flag.h
+++ b/src/flag.h
@@ -143,7 +143,7 @@ class Flag : public GameObject {
   /* Whether the given direction has a resource pickup scheduled. */
   bool is_scheduled(Direction dir) const {
     return (other_end_dir[dir] >> 7) & 1; }
-  bool pick_up_resource(int slot, Resource::Type *res, unsigned int *dest);
+  bool pick_up_resource(unsigned int slot, Resource::Type *res, unsigned int *dest);
   bool drop_resource(Resource::Type res, unsigned int dest);
   bool has_empty_slot() const;
   void remove_all_resources();

--- a/src/game.cc
+++ b/src/game.cc
@@ -2387,8 +2387,6 @@ Game::load_flags(SaveReaderBinary *reader, int max_flag_index) {
   return true;
 }
 
-#include <bitset>
-
 /* Load buildings state from save game. */
 bool
 Game::load_buildings(SaveReaderBinary *reader, int max_building_index) {
@@ -2403,9 +2401,6 @@ Game::load_buildings(SaveReaderBinary *reader, int max_building_index) {
     if (BIT_TEST(bitmap[(i)>>3], 7-((i)&7))) {
       Building *building = buildings.get_or_insert(i);
       building_reader >> *building;
-      if (building->get_type() == Building::TypeNone) {
-        buildings.erase(i);
-      }
     }
   }
 

--- a/src/gfx.cc
+++ b/src/gfx.cc
@@ -190,6 +190,12 @@ Frame::draw_sprite_relatively(int x, int y, Data::Resource res,
                               unsigned int relative_to_index) {
   PSprite s = data_source->get_sprite(relative_to_res, relative_to_index,
                                       {0, 0, 0, 0});
+  if (s == nullptr) {
+    Log::Warn["graphics"] << "Failed to decode sprite #"
+                          << Data::get_resource_name(res) << ":" << index;
+    return;
+  }
+
   x += s->get_delta_x();
   y += s->get_delta_y();
 

--- a/src/serf.h
+++ b/src/serf.h
@@ -172,10 +172,10 @@ class Serf : public GameObject {
     } idle_in_stock;
 
     /* States: walking, transporting, delivering */
-    /* res: resource carried (when transporting),
-       otherwise direction. */
+    /* res: resource carried (when transporting), otherwise direction. */
     struct {
-      int res; /* B */
+      int dir1; /* newly added */
+      Resource::Type res; /* B */
       unsigned int dest; /* C */
       int dir; /* E */
       int wait_counter; /* F */
@@ -262,7 +262,7 @@ class Serf : public GameObject {
 
     struct {
       unsigned int substate; /* B */
-      unsigned int res; /* D */
+      int res; /* D */
       Map::Minerals deposit; /* E */
     } mining;
 
@@ -444,7 +444,7 @@ class Serf : public GameObject {
     operator << (SaveWriterText &writer, Serf &serf);
 
  protected:
-  int is_waiting(Direction *dir);
+  bool is_waiting(Direction *dir);
   int switch_waiting(Direction dir);
   int get_walking_animation(int h_diff, Direction dir, int switch_pos);
   void change_direction(Direction dir, int alt_end);


### PR DESCRIPTION
Fixed: legacy transporter state loading
Fixed: crash on drawing if wrong sprite index occurs