### PR TITLE
Add LGTM code quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Build status
 
 [![Build Status](https://travis-ci.org/freeserf/freeserf.svg?branch=master)](https://travis-ci.org/freeserf/freeserf)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/freeserf/freeserf?branch=master&svg=true)](https://ci.appveyor.com/project/jonls/freeserf)
+[![Code Quality: Cpp](https://img.shields.io/lgtm/grade/cpp/g/freeserf/freeserf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/freeserf/freeserf/context:cpp)
+[![Total Alerts](https://img.shields.io/lgtm/alerts/g/freeserf/freeserf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/freeserf/freeserf/alerts)
 
 Last build downloads
 --------------------


### PR DESCRIPTION
Hi there!

I thought you might be interested in adding these LGTM [code quality badges](https://lgtm.com/projects/g/freeserf/freeserf/ci/#badges) to your project. They indicate how you care about code quality and encourage your future contributors to do the same.
To get an idea of the analyses reflected by these grades, check the [alerts discovered by LGTM](https://lgtm.com/projects/g/freeserf/freeserf).

N.B.: I am on the team behind LGTM.com, I'd appreciate your feedback on this initiative, whether you're interested or not, if you find time to drop me a line. Thanks.
