### PR TITLE
Fix compilation: update random.h

### DIFF
--- a/src/random.h
+++ b/src/random.h
@@ -23,6 +23,7 @@
 #define SRC_RANDOM_H_
 
 #include <string>
+#include <cstdint>
 
 class Random {
  protected:


### PR DESCRIPTION
error:
```
In file included from /usr/src/freeserf-git/src/freeserf/src/random.cc:22:
/usr/src/freeserf-git/src/freeserf/src/random.h:29:3: error: ‘uint16_t’ does not name a type
   29 |   uint16_t state[3];
      |   ^~~~~~~~
/usr/src/freeserf-git/src/freeserf/src/random.h:26:1: note: ‘uint16_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   25 | #include <string>
  +++ |+#include <cstdint>
   26 | 
```